### PR TITLE
Added duration column in subject activities and modified create/updat…

### DIFF
--- a/src/modules/resources/src/data/activity.types.ts
+++ b/src/modules/resources/src/data/activity.types.ts
@@ -13,6 +13,7 @@ export interface ActivityResponse {
     assignedUserId: string; // Guid from C#
     activityType: string;
     expectedStudents: number | null;
+    duration: number;
 }
 
 /**
@@ -25,6 +26,7 @@ export interface CreateActivityRequest {
     assignedUserId: string; // Guid from C#
     activityType: string;
     expectedStudents: number | null;
+    duration: number;
 }
 
 /**
@@ -37,4 +39,5 @@ export interface UpdateActivityRequest {
     assignedUserId: string; // Guid from C#
     activityType: string;
     expectedStudents: number | null;
+    duration: number;
 }

--- a/src/modules/resources/src/pages/activities-page/activities-page.resources.json
+++ b/src/modules/resources/src/pages/activities-page/activities-page.resources.json
@@ -7,6 +7,7 @@
     "activityTypeColumn": "Type",
     "assignedUserColumn": "Instructor",
     "expectedStudentsColumn": "Expected Students",
+    "durationColumn": "Duration",
     "emptyStateMessage": "No groups for this course yet.",
     "deleteConfirmTitle": "Delete Group",
     "deleteConfirmMessage": "Are you sure you want to delete this group?",

--- a/src/modules/resources/src/pages/activities-page/activities-page.tsx
+++ b/src/modules/resources/src/pages/activities-page/activities-page.tsx
@@ -104,6 +104,7 @@ export function ActivitiesPage() {
         activityType: string; 
         assignedUserId: string; 
         expectedStudents: number | null;
+        duration: number;
     }) => {
         $app.logger.info("[ActivitiesPage] handleCreateSubmit called with:", data);
         
@@ -129,6 +130,7 @@ export function ActivitiesPage() {
             assignedUserId: data.assignedUserId || "",
             activityType: data.activityType,
             expectedStudents: data.expectedStudents,
+            duration: data.duration,
         };
 
         $app.logger.info("[ActivitiesPage] Sending create request:", request);
@@ -164,6 +166,7 @@ export function ActivitiesPage() {
         activityType: string;
         assignedUserId: string;
         expectedStudents: number | null;
+        duration: number;
     }) => {
         $app.logger.info("[ActivitiesPage] handleEditSubmit called with:", data);
         $app.logger.info("[ActivitiesPage] selectedActivity:", selectedActivity);
@@ -189,6 +192,7 @@ export function ActivitiesPage() {
             assignedUserId: data.assignedUserId || "",
             activityType: data.activityType,
             expectedStudents: data.expectedStudents,
+            duration: data.duration,
         };
 
         $app.logger.info("[ActivitiesPage] Sending update request:", request);
@@ -248,6 +252,7 @@ export function ActivitiesPage() {
                 assignedUserId: activity.assignedUserId,
                 assignedUserName: userName,
                 expectedStudents: activity.expectedStudents || 0,
+                duration: activity.duration,
             };
         });
 
@@ -319,6 +324,7 @@ export function ActivitiesPage() {
                                   activityType: selectedActivity.activityType,
                                   assignedUserId: selectedActivity.assignedUserId,
                                   expectedStudents: selectedActivity.expectedStudents || 0,
+                                  duration: selectedActivity.duration,
                               }
                             : undefined
                     }

--- a/src/modules/resources/src/pages/activities-page/components/activity-creator.tsx
+++ b/src/modules/resources/src/pages/activities-page/components/activity-creator.tsx
@@ -9,6 +9,7 @@ interface ActivityCreatorProps {
         activityType: string;
         assignedUserId: string;
         expectedStudents: number | null;
+        duration: number;
     }) => Promise<void>;
     loading?: boolean;
 }
@@ -22,6 +23,8 @@ export function ActivityCreator({
     const [activityType, setActivityType] = useState("");
     const [assignedUserId, setAssignedUserId] = useState<string | null>(null);
     const [expectedStudents, setExpectedStudents] = useState<number | null>(null);
+    const [duration, setDuration] = useState<number>(0);
+    const [durationTouched, setDurationTouched] = useState(false);
     const [users, setUsers] = useState<{ value: string; label: string }[]>([]);
     const [isLoadingUsers, setIsLoadingUsers] = useState(false);
 
@@ -55,10 +58,18 @@ export function ActivityCreator({
             activityType,
             assignedUserId,
             expectedStudents,
+            duration,
         });
+
+        setDurationTouched(true);
 
         if (!activityType.trim()) {
             $app.logger.warn("[ActivityCreator] Validation failed - empty activity type");
+            return;
+        }
+
+        if (duration <= 0) {
+            $app.notifications.showWarning("Validation", "Duration must be greater than 0");
             return;
         }
 
@@ -67,18 +78,23 @@ export function ActivityCreator({
             activityType,
             assignedUserId: assignedUserId || "",
             expectedStudents,
+            duration,
         });
 
         $app.logger.info("[ActivityCreator] onSubmit completed, resetting form");
         setActivityType("");
         setAssignedUserId(null);
         setExpectedStudents(null);
+        setDuration(0);
+        setDurationTouched(false);
     };
 
     const handleClose = () => {
         setActivityType("");
         setAssignedUserId(null);
         setExpectedStudents(null);
+        setDuration(0);
+        setDurationTouched(false);
         onClose();
     };
 
@@ -109,10 +125,20 @@ export function ActivityCreator({
                     onChange={(value) => setExpectedStudents(value === "" ? null : Number(value))}
                     min={0}
                 />
+                <NumberInput
+                    label="Duration"
+                    placeholder="Duration in hours"
+                    value={duration}
+                    onChange={(value) => setDuration(value === "" ? 0 : Number(value))}
+                    onBlur={() => setDurationTouched(true)}
+                    min={0}
+                    required
+                    error={durationTouched && duration <= 0 ? "Duration must be greater than 0" : undefined}
+                />
                 <Button
                     onClick={handleSubmit}
                     loading={loading}
-                    disabled={!activityType.trim() || isLoadingUsers}
+                    disabled={!activityType.trim() || isLoadingUsers || duration <= 0}
                     fullWidth
                 >
                     Create Group

--- a/src/modules/resources/src/pages/activities-page/components/activity-editor.tsx
+++ b/src/modules/resources/src/pages/activities-page/components/activity-editor.tsx
@@ -9,12 +9,14 @@ interface ActivityEditorProps {
         activityType: string;
         assignedUserId: string;
         expectedStudents: number | null;
+        duration: number;
     }) => Promise<void>;
     readonly loading?: boolean;
     readonly initialData?: {
         readonly activityType: string;
         readonly assignedUserId: string;
         readonly expectedStudents: number | null;
+        readonly duration: number;
     };
 }
 
@@ -28,6 +30,8 @@ export function ActivityEditor({
     const [activityType, setActivityType] = useState("");
     const [assignedUserId, setAssignedUserId] = useState<string | null>(null);
     const [expectedStudents, setExpectedStudents] = useState<number | null>(null);
+    const [duration, setDuration] = useState<number>(0);
+    const [durationTouched, setDurationTouched] = useState(false);
     const [users, setUsers] = useState<{ value: string; label: string }[]>([]);
     const [isLoadingUsers, setIsLoadingUsers] = useState(false);
 
@@ -41,11 +45,12 @@ export function ActivityEditor({
     useEffect(() => {
         if (initialData) {
             setActivityType(initialData.activityType);
-            // Check if assigned user is empty or unassigned, if so set to null
             const isUnassigned = !initialData.assignedUserId || 
                 initialData.assignedUserId.trim().length === 0;
             setAssignedUserId(isUnassigned ? null : initialData.assignedUserId);
             setExpectedStudents(initialData.expectedStudents);
+            setDuration(initialData.duration);
+            setDurationTouched(false);
         }
     }, [initialData]);
 
@@ -72,10 +77,18 @@ export function ActivityEditor({
             activityType,
             assignedUserId,
             expectedStudents,
+            duration,
         });
+
+        setDurationTouched(true);
 
         if (!activityType.trim()) {
             $app.logger.warn("[ActivityEditor] Validation failed - empty activity type");
+            return;
+        }
+
+        if (duration <= 0) {
+            $app.notifications.showWarning("Validation", "Duration must be greater than 0");
             return;
         }
 
@@ -84,18 +97,23 @@ export function ActivityEditor({
             activityType,
             assignedUserId: assignedUserId || "",
             expectedStudents,
+            duration,
         });
 
         $app.logger.info("[ActivityEditor] onSubmit completed, resetting form");
         setActivityType("");
         setAssignedUserId(null);
         setExpectedStudents(null);
+        setDuration(0);
+        setDurationTouched(false);
     };
 
     const handleClose = () => {
         setActivityType("");
         setAssignedUserId(null);
         setExpectedStudents(null);
+        setDuration(0);
+        setDurationTouched(false);
         onClose();
     };
 
@@ -126,10 +144,20 @@ export function ActivityEditor({
                     onChange={(value) => setExpectedStudents(value === "" ? null : Number(value))}
                     min={0}
                 />
+                <NumberInput
+                    label="Duration"
+                    placeholder="Duration in hours"
+                    value={duration}
+                    onChange={(value) => setDuration(value === "" ? 0 : Number(value))}
+                    onBlur={() => setDurationTouched(true)}
+                    min={0}
+                    required
+                    error={durationTouched && duration <= 0 ? "Duration must be greater than 0" : undefined}
+                />
                 <Button
                     onClick={handleSubmit}
                     loading={loading}
-                    disabled={!activityType.trim() || isLoadingUsers}
+                    disabled={!activityType.trim() || isLoadingUsers || duration <= 0}
                     fullWidth
                 >
                     Save Changes

--- a/src/modules/resources/src/pages/activities-page/components/activity-table/activity-table.tsx
+++ b/src/modules/resources/src/pages/activities-page/components/activity-table/activity-table.tsx
@@ -65,6 +65,11 @@ export function ActivityTable({
                 sortable 
                 body={(rowData: ActivityData) => rowData.expectedStudents ?? "N/A"}
             />
+            <Column 
+                field="duration" 
+                header={resources.durationColumn} 
+                sortable 
+            />
         </DataTable>
     );
 }

--- a/src/modules/resources/src/pages/activities-page/components/activity-table/types.ts
+++ b/src/modules/resources/src/pages/activities-page/components/activity-table/types.ts
@@ -4,4 +4,5 @@ export type ActivityData = {
     assignedUserId: string;
     assignedUserName: string;
     expectedStudents: number | null;
+    duration: number;
 };


### PR DESCRIPTION
## Description

Activity was updated with new field - duration. In Courses page, duration column was added, and the modals of create/update activity were modified with new text input for duration. Duration is required field.

## Related Issue

Closes bgu-nasa/main#57

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Module(s) Affected

Resources

## Checklist

- [x] My code follows the project [contribution rules](../README.md#contribution-rules)
- [ ] I used CSS modules (no inline CSS unless necessary)
- [ ] I used absolute imports with `@/` prefix
- [ ] Display strings are in `*.resources.json` files
- [ ] File and directory names use kebab-case
- [ ] I have added/updated JSDoc comments where appropriate
- [ ] I ran `npm run lint` with no errors
- [x] I have tested my changes locally

## Screenshots (if applicable)

<img width="1537" height="702" alt="image" src="https://github.com/user-attachments/assets/caa44f1b-e133-4bf9-a6cd-73516451de5a" />

<img width="522" height="498" alt="image" src="https://github.com/user-attachments/assets/98fd39ab-7329-454c-8304-a0e1f169d982" />

<img width="538" height="537" alt="image" src="https://github.com/user-attachments/assets/9e973eb8-6101-4171-ab4b-5a71dffd6d19" />


## Additional Notes

Right now this field is defined as integer. We will need to discuss with the customer and understand if duration might be non-integer.
