### PR TITLE
Implement one-time forbidden time-range constraints for user scheduling

### DIFF
--- a/src/modules/schedule/src/data/constraints.types.ts
+++ b/src/modules/schedule/src/data/constraints.types.ts
@@ -12,6 +12,7 @@ export interface UserConstraintResponse {
     userId: string;
     organizationId: string;
     schedulingPeriodId: string;
+    weekNum?: number | null;
     key: string;
     value: string;
 }
@@ -19,11 +20,13 @@ export interface UserConstraintResponse {
 export interface CreateUserConstraintRequest {
     userId: string;
     schedulingPeriodId: string;
+    weekNum?: number | null;
     key: string;
     value: string;
 }
 
 export interface UpdateUserConstraintRequest {
+    weekNum?: number | null;
     key: string;
     value: string;
 }
@@ -60,17 +63,20 @@ export interface ActivityConstraintResponse {
     id: string;
     activityId: string;
     organizationId: string;
+    weekNum?: number | null;
     key: string;
     value: string;
 }
 
 export interface CreateActivityConstraintRequest {
     activityId: string;
+    weekNum?: number | null;
     key: string;
     value: string;
 }
 
 export interface UpdateActivityConstraintRequest {
+    weekNum?: number | null;
     key: string;
     value: string;
 }

--- a/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
+++ b/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { HiOutlineTrash } from "react-icons/hi";
 
-import {
-    Modal, TextInput, Button, Text,
-    Group, Select, MultiSelect,
-    ActionIcon, Stack
-} from "@mantine/core";
+import { ActionIcon, Button, Group, Modal, MultiSelect, Select, Stack, Text, TextInput } from "@mantine/core";
 import { TimeInput } from "@mantine/dates";
 
 import { useUsers } from "@/modules/auth/src/hooks";
@@ -13,32 +9,207 @@ import { useSchedulingPeriods } from "@/modules/schedule/src/hooks";
 
 import resources from "../constraints-page.resources.json";
 import {
-    parseForbiddenTimeRange, parsePreferredWeekdays, parsePreferredTimeRange,
-    serializeForbiddenTimeRange, serializePreferredWeekdays, serializePreferredTimeRange,
-    type ForbiddenTimeRangeEntry
+    parseForbiddenTimeRange,
+    parsePreferredTimeRange,
+    parsePreferredWeekdays,
+    serializeForbiddenTimeRange,
+    serializePreferredTimeRange,
+    serializePreferredWeekdays,
+    type ForbiddenTimeRangeEntry,
 } from "../utils";
+
+type ConstraintMode = "repeated" | "oneTime";
+
+interface UserConstraintEditorSubmitData {
+    userId: string;
+    schedulingPeriodId: string;
+    key: string;
+    value: string;
+    weekNum: number | null;
+    isPreference: boolean;
+}
 
 interface UserConstraintEditorProps {
     readonly opened: boolean;
     readonly onClose: () => void;
-    readonly onSubmit: (data: {
-        userId: string;
-        schedulingPeriodId: string;
-        key: string;
-        value: string;
-        isPreference: boolean;
-    }) => Promise<void>;
+    readonly onSubmit: (data: UserConstraintEditorSubmitData) => Promise<void>;
     readonly initialData?: {
         userId: string;
         schedulingPeriodId: string;
         key: string;
         value: string;
+        weekNum?: number | null;
         isPreference: boolean;
     };
     readonly isAdmin: boolean;
     readonly currentUserId?: string;
     readonly loading?: boolean;
     readonly isPreference: boolean;
+}
+
+const weekdays = resources.other.weekdays;
+
+function normalizeWeekday(weekday: string) {
+    if (!weekday) {
+        return weekday;
+    }
+
+    return weekday.charAt(0).toUpperCase() + weekday.slice(1).toLowerCase();
+}
+
+function createDateKey(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}
+
+function getWeekdayFromDateKey(dateKey: string) {
+    if (!dateKey) {
+        return "";
+    }
+
+    const [year, month, day] = dateKey.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    return weekdays[date.getDay()] || "";
+}
+
+function getIsoWeekNumber(dateKey: string) {
+    const [year, month, day] = dateKey.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    const dayNumber = (utcDate.getUTCDay() + 6) % 7;
+    utcDate.setUTCDate(utcDate.getUTCDate() - dayNumber + 3);
+
+    const firstThursday = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 4));
+    const firstThursdayDayNumber = (firstThursday.getUTCDay() + 6) % 7;
+    firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNumber + 3);
+
+    return 1 + Math.round((utcDate.getTime() - firstThursday.getTime()) / 604800000);
+}
+
+function getDateFromIsoWeek(year: number, weekNum: number, weekday: string) {
+    const normalizedWeekday = normalizeWeekday(weekday);
+    const weekdayIndex = weekdays.indexOf(normalizedWeekday);
+    if (weekdayIndex < 0) {
+        return "";
+    }
+
+    const week1Thursday = new Date(Date.UTC(year, 0, 4));
+    const week1ThursdayDayNumber = (week1Thursday.getUTCDay() + 6) % 7;
+    week1Thursday.setUTCDate(week1Thursday.getUTCDate() - week1ThursdayDayNumber + 3);
+
+    const isoWeekdayOffset = (weekdayIndex + 6) % 7;
+    const date = new Date(week1Thursday);
+    date.setUTCDate(week1Thursday.getUTCDate() + (weekNum - 1) * 7 + isoWeekdayOffset - 3);
+
+    return createDateKey(new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function createEmptyTimeRangeEntry(): ForbiddenTimeRangeEntry & { id: string } {
+    return {
+        weekday: "",
+        startTime: "",
+        endTime: "",
+        id: `entry-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
+    };
+}
+
+function getMinutesFromTime(time: string) {
+    const [hours, minutes] = time.split(":").map(Number);
+    return hours * 60 + minutes;
+}
+
+function isValidTimeRange(entry: Pick<ForbiddenTimeRangeEntry, "startTime" | "endTime">) {
+    return getMinutesFromTime(entry.startTime) < getMinutesFromTime(entry.endTime);
+}
+
+function validateRepeatedForbiddenTimeRanges(entries: Array<ForbiddenTimeRangeEntry>): string | null {
+    const validEntries = entries.filter(entry => entry.weekday && entry.startTime && entry.endTime);
+
+    if (validEntries.length === 0) {
+        return resources.validationMessages.atLeastOneTimeRange;
+    }
+
+    return validEntries.some(entry => !isValidTimeRange(entry))
+        ? resources.validationMessages.startTimeBeforeEndTime
+        : null;
+}
+
+function validateOneTimeForbiddenTimeRange(
+    entries: Array<ForbiddenTimeRangeEntry>,
+    oneTimeDate: string,
+    selectedSchedulingPeriod?: { fromDate: string; toDate: string }
+): { value?: string; date?: string } | null {
+    if (!oneTimeDate) {
+        return { date: resources.validationMessages.oneTimeDateRequired };
+    }
+
+    if (!selectedSchedulingPeriod) {
+        return { date: resources.validationMessages.schedulingPeriodRequired };
+    }
+
+    const periodStartKey = selectedSchedulingPeriod.fromDate.split("T")[0];
+    const periodEndKey = selectedSchedulingPeriod.toDate.split("T")[0];
+
+    if (oneTimeDate < periodStartKey || oneTimeDate > periodEndKey) {
+        return { date: resources.validationMessages.oneTimeDateOutOfRange };
+    }
+
+    const validEntries = entries.filter(entry => entry.startTime && entry.endTime);
+
+    if (validEntries.length !== 1) {
+        return { value: resources.validationMessages.atLeastOneTimeRange };
+    }
+
+    return isValidTimeRange(validEntries[0])
+        ? null
+        : { value: resources.validationMessages.startTimeBeforeEndTime };
+}
+
+function serializeConstraintValue(
+    key: string,
+    constraintMode: ConstraintMode,
+    timeRangeEntries: Array<ForbiddenTimeRangeEntry & { id: string }>,
+    oneTimeDate: string,
+    selectedWeekdays: string[]
+) {
+    if (key === "forbidden_timerange") {
+        const entriesWithoutIds = timeRangeEntries.map(({ id, ...entry }) => entry);
+
+        if (constraintMode === "oneTime") {
+            const entry = entriesWithoutIds[0];
+
+            return {
+                serializedValue: serializeForbiddenTimeRange([
+                    {
+                        weekday: getWeekdayFromDateKey(oneTimeDate) || entry?.weekday || "",
+                        startTime: entry?.startTime || "",
+                        endTime: entry?.endTime || "",
+                    },
+                ]),
+                weekNum: getIsoWeekNumber(oneTimeDate),
+            };
+        }
+
+        return {
+            serializedValue: serializeForbiddenTimeRange(entriesWithoutIds),
+            weekNum: null,
+        };
+    }
+
+    if (key === "preferred_timerange") {
+        const entriesWithoutIds = timeRangeEntries.map(({ id, ...entry }) => entry);
+        return {
+            serializedValue: serializePreferredTimeRange(entriesWithoutIds),
+            weekNum: null,
+        };
+    }
+
+    return {
+        serializedValue: serializePreferredWeekdays(selectedWeekdays),
+        weekNum: null,
+    };
 }
 
 export function UserConstraintEditor({
@@ -54,16 +225,13 @@ export function UserConstraintEditor({
     const { users, fetchUsers } = useUsers();
     const { schedulingPeriods, fetchSchedulingPeriods } = useSchedulingPeriods();
 
-    // Form state for forbidden_timerange: array of time range entries with unique IDs
     const [timeRangeEntries, setTimeRangeEntries] = useState<Array<ForbiddenTimeRangeEntry & { id: string }>>([]);
-
-    // Form state for preferred_weekdays: array of selected weekdays
     const [selectedWeekdays, setSelectedWeekdays] = useState<string[]>([]);
+    const [constraintMode, setConstraintMode] = useState<ConstraintMode>("repeated");
+    const [oneTimeDate, setOneTimeDate] = useState<string>("");
 
-    // Determine default constraint key based on isPreference
     const defaultConstraintKey = isPreference ? "preferred_weekdays" : "forbidden_timerange";
 
-    // Form state - must be declared before constraintKey useMemo
     const [formValues, setFormValues] = useState({
         userId: initialData?.userId || currentUserId || "",
         schedulingPeriodId: initialData?.schedulingPeriodId || "",
@@ -71,17 +239,14 @@ export function UserConstraintEditor({
         isPreference: initialData?.isPreference ?? isPreference,
     });
 
-    // Determine the constraint key based on isPreference
-    // When editing, use initialData.key; when creating, use formValues.key (which can be changed by user)
     const constraintKey = useMemo(() => {
         if (initialData?.key) {
             return initialData.key;
         }
-        // Use formValues.key if set, otherwise default based on isPreference
-        return formValues.key || defaultConstraintKey;
-    }, [initialData?.key, isPreference, formValues.key]);
 
-    // Get the constraint type options and label
+        return formValues.key || defaultConstraintKey;
+    }, [initialData?.key, formValues.key, defaultConstraintKey]);
+
     const constraintTypeOptions = useMemo(() => {
         return isPreference
             ? resources.constraintTypeOptions.userPreferences
@@ -89,22 +254,28 @@ export function UserConstraintEditor({
     }, [isPreference]);
 
     const constraintTypeLabel = useMemo(() => {
-        return constraintTypeOptions.find(opt => opt.value === constraintKey)?.label || constraintKey;
+        return constraintTypeOptions.find((opt) => opt.value === constraintKey)?.label || constraintKey;
     }, [constraintKey, constraintTypeOptions]);
 
+    const selectedSchedulingPeriod = useMemo(
+        () => schedulingPeriods.find(period => period.id === formValues.schedulingPeriodId),
+        [schedulingPeriods, formValues.schedulingPeriodId]
+    );
+
     const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+    const isOneTimeForbiddenEdit = Boolean(
+        initialData?.key === "forbidden_timerange" &&
+        initialData.weekNum !== null &&
+        initialData.weekNum !== undefined
+    );
 
     useEffect(() => {
         if (opened) {
             fetchUsers();
             fetchSchedulingPeriods();
         }
-    }, [opened]);
+    }, [opened, fetchUsers, fetchSchedulingPeriods]);
 
-    // Generate unique ID for time range entries
-    const generateEntryId = () => `entry-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
-
-    // Initialize form data when editing
     const initializeEditData = () => {
         if (!initialData) return;
 
@@ -115,35 +286,58 @@ export function UserConstraintEditor({
             isPreference: initialData.isPreference,
         });
         setFormErrors({});
+        setConstraintMode(isOneTimeForbiddenEdit ? "oneTime" : "repeated");
 
-        // Parse the value based on constraint type
         if (initialData.key === "forbidden_timerange" || initialData.key === "preferred_timerange") {
             const entries = initialData.key === "forbidden_timerange"
                 ? parseForbiddenTimeRange(initialData.value)
                 : parsePreferredTimeRange(initialData.value);
+
             const entriesWithIds = entries.length > 0
-                ? entries.map(e => ({ ...e, id: generateEntryId() }))
-                : [{ weekday: "", startTime: "", endTime: "", id: generateEntryId() }];
+                ? entries.map(entry => ({ ...entry, id: `entry-${Date.now()}-${Math.random().toString(36).slice(2, 11)}` }))
+                : [createEmptyTimeRangeEntry()];
+
             setTimeRangeEntries(entriesWithIds);
+            setOneTimeDate("");
         } else if (initialData.key === "preferred_weekdays") {
-            const weekdays = parsePreferredWeekdays(initialData.value);
-            setSelectedWeekdays(weekdays);
+            setSelectedWeekdays(parsePreferredWeekdays(initialData.value));
         }
     };
 
-    // Initialize form data when creating new
+    useEffect(() => {
+        if (!opened || !initialData || !isOneTimeForbiddenEdit) {
+            return;
+        }
+
+        const selectedPeriod = schedulingPeriods.find(period => period.id === initialData.schedulingPeriodId);
+        if (!selectedPeriod) {
+            return;
+        }
+
+        const parsedEntries = parseForbiddenTimeRange(initialData.value);
+        const firstEntry = parsedEntries[0];
+
+        if (!firstEntry || oneTimeDate) {
+            return;
+        }
+
+        const year = new Date(selectedPeriod.fromDate).getFullYear();
+        setOneTimeDate(getDateFromIsoWeek(year, initialData.weekNum!, firstEntry.weekday));
+    }, [opened, initialData, isOneTimeForbiddenEdit, schedulingPeriods, oneTimeDate]);
+
     const initializeNewData = () => {
         setFormValues({
             userId: !isAdmin && currentUserId ? currentUserId : "",
             schedulingPeriodId: "",
             key: constraintKey,
-            isPreference: isPreference,
+            isPreference,
         });
         setFormErrors({});
+        setConstraintMode("repeated");
+        setOneTimeDate("");
 
-        // Initialize empty form data based on constraint type
         if (constraintKey === "forbidden_timerange" || constraintKey === "preferred_timerange") {
-            setTimeRangeEntries([{ weekday: "", startTime: "", endTime: "", id: generateEntryId() }]);
+            setTimeRangeEntries([createEmptyTimeRangeEntry()]);
         } else if (constraintKey === "preferred_weekdays") {
             setSelectedWeekdays([]);
         }
@@ -159,20 +353,40 @@ export function UserConstraintEditor({
         }
     }, [opened, initialData, isAdmin, currentUserId, isPreference, constraintKey]);
 
+    const validateForm = (): { value?: string; date?: string } | null => {
+        if (constraintKey === "forbidden_timerange") {
+            if (constraintMode === "oneTime") {
+                return validateOneTimeForbiddenTimeRange(timeRangeEntries, oneTimeDate, selectedSchedulingPeriod);
+            }
+
+            const validationMessage = validateRepeatedForbiddenTimeRanges(timeRangeEntries);
+            return validationMessage ? { value: validationMessage } : null;
+        }
+
+        if (constraintKey === "preferred_weekdays" && selectedWeekdays.length === 0) {
+            return { value: resources.validationMessages.atLeastOneWeekday };
+        }
+
+        return null;
+    };
+
     const handleSubmit = async () => {
-        // Validate form fields
         const errors: Record<string, string> = {};
+
         if (!formValues.userId) {
             errors.userId = resources.validationMessages.userRequired;
         }
+
         if (!formValues.schedulingPeriodId) {
             errors.schedulingPeriodId = resources.validationMessages.schedulingPeriodRequired;
         }
 
-        // Validate constraint-specific fields
-        const validationError = validateForm();
-        if (validationError) {
-            errors.value = validationError;
+        const validationErrors = validateForm();
+        if (validationErrors?.value) {
+            errors.value = validationErrors.value;
+        }
+        if (validationErrors?.date) {
+            errors.oneTimeDate = validationErrors.date;
         }
 
         if (Object.keys(errors).length > 0) {
@@ -181,35 +395,30 @@ export function UserConstraintEditor({
         }
 
         try {
-            // Serialize form data based on constraint type
-            let serializedValue = "";
-
-            if (constraintKey === "forbidden_timerange") {
-                // Remove id field before serializing
-                const entriesWithoutIds = timeRangeEntries.map(({ id, ...entry }) => entry);
-                serializedValue = serializeForbiddenTimeRange(entriesWithoutIds);
-            } else if (constraintKey === "preferred_timerange") {
-                // Remove id field before serializing
-                const entriesWithoutIds = timeRangeEntries.map(({ id, ...entry }) => entry);
-                serializedValue = serializePreferredTimeRange(entriesWithoutIds);
-            } else if (constraintKey === "preferred_weekdays") {
-                serializedValue = serializePreferredWeekdays(selectedWeekdays);
-            }
+            const { serializedValue, weekNum } = serializeConstraintValue(
+                constraintKey,
+                constraintMode,
+                timeRangeEntries,
+                oneTimeDate,
+                selectedWeekdays
+            );
 
             await onSubmit({
                 ...formValues,
                 value: serializedValue,
+                weekNum,
                 isPreference: initialData?.isPreference ?? isPreference,
             });
 
-            // Reset form
             setFormValues({
                 userId: !isAdmin && currentUserId ? currentUserId : "",
                 schedulingPeriodId: "",
                 key: constraintKey,
-                isPreference: isPreference,
+                isPreference,
             });
             setFormErrors({});
+            setConstraintMode("repeated");
+            setOneTimeDate("");
             setTimeRangeEntries([]);
             setSelectedWeekdays([]);
             onClose();
@@ -223,7 +432,7 @@ export function UserConstraintEditor({
     };
 
     const addTimeRangeEntry = () => {
-        setTimeRangeEntries([...timeRangeEntries, { weekday: "", startTime: "", endTime: "", id: generateEntryId() }]);
+        setTimeRangeEntries([...timeRangeEntries, createEmptyTimeRangeEntry()]);
     };
 
     const removeTimeRangeEntry = (id: string) => {
@@ -236,34 +445,6 @@ export function UserConstraintEditor({
         ));
     };
 
-    // Validation for form submission
-    const validateForm = (): string | null => {
-        if (constraintKey === "forbidden_timerange" || constraintKey === "preferred_timerange") {
-            const validEntries = timeRangeEntries.filter(e => e.weekday && e.startTime && e.endTime);
-            if (validEntries.length === 0) {
-                return resources.validationMessages.atLeastOneTimeRange;
-            }
-
-            // Validate each entry
-            for (const entry of validEntries) {
-                const [startHours, startMinutes] = entry.startTime.split(':').map(Number);
-                const [endHours, endMinutes] = entry.endTime.split(':').map(Number);
-                const startTotal = startHours * 60 + startMinutes;
-                const endTotal = endHours * 60 + endMinutes;
-
-                if (startTotal >= endTotal) {
-                    return resources.validationMessages.startTimeBeforeEndTime;
-                }
-            }
-        } else if (constraintKey === "preferred_weekdays") {
-            if (selectedWeekdays.length === 0) {
-                return resources.validationMessages.atLeastOneWeekday;
-            }
-        }
-        return null;
-    };
-
-    // Handle form submission with validation
     const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         handleSubmit();
@@ -279,24 +460,15 @@ export function UserConstraintEditor({
         label: period.name,
     }));
 
-    let modalTitle: string;
+    let modalTitle = resources.modalTitles.createUserConstraint;
     if (initialData) {
-        modalTitle = isPreference
-            ? resources.modalTitles.editUserPreference
-            : resources.modalTitles.editUserConstraint;
-    } else {
-        modalTitle = isPreference
-            ? resources.modalTitles.createUserPreference
-            : resources.modalTitles.createUserConstraint;
+        modalTitle = isPreference ? resources.modalTitles.editUserPreference : resources.modalTitles.editUserConstraint;
+    } else if (isPreference) {
+        modalTitle = resources.modalTitles.createUserPreference;
     }
 
     return (
-        <Modal
-            opened={opened}
-            onClose={onClose}
-            title={modalTitle}
-            size={resources.modalSize}
-        >
+        <Modal opened={opened} onClose={onClose} title={modalTitle} size={resources.modalSize}>
             <form onSubmit={handleFormSubmit}>
                 {isAdmin ? (
                     <Select
@@ -318,12 +490,10 @@ export function UserConstraintEditor({
                 ) : (
                     <TextInput
                         label={resources.labels.user}
-                        value={
-                            (() => {
-                                const user = users.find((u) => u.id === currentUserId);
-                                return user ? `${user.firstName} ${user.lastName}` : resources.other.currentUser;
-                            })()
-                        }
+                        value={(() => {
+                            const user = users.find((u) => u.id === currentUserId);
+                            return user ? `${user.firstName} ${user.lastName}` : resources.other.currentUser;
+                        })()}
                         disabled
                         mb="md"
                     />
@@ -360,26 +530,135 @@ export function UserConstraintEditor({
                         data={constraintTypeOptions}
                         value={constraintKey}
                         onChange={(value) => {
-                            if (value) {
-                                setFormValues({ ...formValues, key: value });
-                                // Reset form data when constraint type changes
-                                if (value === "forbidden_timerange" || value === "preferred_timerange") {
-                                    setTimeRangeEntries([{ weekday: "", startTime: "", endTime: "", id: generateEntryId() }]);
-                                    setSelectedWeekdays([]);
-                                } else if (value === "preferred_weekdays") {
-                                    setTimeRangeEntries([]);
-                                    setSelectedWeekdays([]);
-                                }
-                                if (formErrors.value) {
-                                    setFormErrors({ ...formErrors, value: "" });
-                                }
+                            if (!value) {
+                                return;
+                            }
+
+                            setFormValues({ ...formValues, key: value });
+                            if (value === "forbidden_timerange" || value === "preferred_timerange") {
+                                setTimeRangeEntries([createEmptyTimeRangeEntry()]);
+                                setSelectedWeekdays([]);
+                                setConstraintMode("repeated");
+                                setOneTimeDate("");
+                            } else if (value === "preferred_weekdays") {
+                                setTimeRangeEntries([]);
+                                setSelectedWeekdays([]);
+                            }
+
+                            if (formErrors.value) {
+                                setFormErrors({ ...formErrors, value: "" });
                             }
                         }}
                         mb="md"
                     />
                 )}
 
-                {(constraintKey === "forbidden_timerange" || constraintKey === "preferred_timerange") && (
+                {constraintKey === "forbidden_timerange" && (
+                    <Stack gap="md" mb="md">
+                        <Select
+                            label={resources.labels.constraintMode}
+                            data={resources.constraintModes}
+                            value={constraintMode}
+                            onChange={(value) => {
+                                const nextMode = (value as ConstraintMode) || "repeated";
+                                setConstraintMode(nextMode);
+                                setFormErrors({ ...formErrors, value: "", oneTimeDate: "" });
+
+                                const firstEntry = timeRangeEntries[0] ?? createEmptyTimeRangeEntry();
+                                setTimeRangeEntries([
+                                    {
+                                        ...firstEntry,
+                                        weekday: nextMode === "oneTime" && oneTimeDate
+                                            ? getWeekdayFromDateKey(oneTimeDate)
+                                            : firstEntry.weekday,
+                                    },
+                                ]);
+                            }}
+                        />
+
+                        {constraintMode === "oneTime" && (
+                            <TextInput
+                                label={resources.labels.date}
+                                placeholder={resources.placeholders.selectDate}
+                                type="date"
+                                value={oneTimeDate}
+                                onChange={(event) => {
+                                    const value = event.currentTarget.value;
+                                    setOneTimeDate(value);
+                                    setFormErrors({ ...formErrors, oneTimeDate: "" });
+                                    setTimeRangeEntries(previousEntries => {
+                                        const firstEntry = previousEntries[0] ?? createEmptyTimeRangeEntry();
+                                        return [{ ...firstEntry, weekday: getWeekdayFromDateKey(value) }];
+                                    });
+                                }}
+                                error={formErrors.oneTimeDate}
+                                required
+                            />
+                        )}
+
+                        <Text size="sm" c="dimmed">
+                            {constraintMode === "oneTime"
+                                ? resources.valueFormatGuidance.forbidden_timerange_oneTime
+                                : resources.valueFormatGuidance.forbidden_timerange}
+                        </Text>
+
+                        {formErrors.value && (
+                            <Text size="sm" c="red" mb="xs">
+                                {formErrors.value}
+                            </Text>
+                        )}
+
+                        {timeRangeEntries.map((entry, index) => (
+                            <Group key={entry.id} align="flex-start" gap="xs">
+                                {constraintMode === "repeated" && (
+                                    <Select
+                                        label={index === 0 ? resources.labels.weekday : undefined}
+                                        placeholder={resources.placeholders.selectWeekday}
+                                        data={resources.other.weekdays}
+                                        value={entry.weekday}
+                                        onChange={(value) => updateTimeRangeEntry(entry.id, "weekday", value || "")}
+                                        style={{ flex: 1 }}
+                                        required
+                                    />
+                                )}
+                                <TimeInput
+                                    label={index === 0 ? resources.labels.startTime : undefined}
+                                    placeholder={resources.placeholders.selectStartTime}
+                                    value={entry.startTime}
+                                    onChange={(e) => updateTimeRangeEntry(entry.id, "startTime", e.currentTarget.value)}
+                                    style={{ flex: 1 }}
+                                    required
+                                />
+                                <TimeInput
+                                    label={index === 0 ? resources.labels.endTime : undefined}
+                                    placeholder={resources.placeholders.selectEndTime}
+                                    value={entry.endTime}
+                                    onChange={(e) => updateTimeRangeEntry(entry.id, "endTime", e.currentTarget.value)}
+                                    style={{ flex: 1 }}
+                                    required
+                                />
+                                {constraintMode === "repeated" && timeRangeEntries.length > 1 && (
+                                    <ActionIcon
+                                        color="red"
+                                        variant="subtle"
+                                        onClick={() => removeTimeRangeEntry(entry.id)}
+                                        mt={index === 0 ? 28 : 0}
+                                    >
+                                        <HiOutlineTrash size={16} />
+                                    </ActionIcon>
+                                )}
+                            </Group>
+                        ))}
+
+                        {constraintMode === "repeated" && (
+                            <Button variant="light" onClick={addTimeRangeEntry} size="sm">
+                                {resources.labels.addTimeRange}
+                            </Button>
+                        )}
+                    </Stack>
+                )}
+
+                {constraintKey === "preferred_timerange" && (
                     <Stack gap="md" mb="md">
                         {formErrors.value && (
                             <Text size="sm" c="red" mb="xs">
@@ -425,11 +704,7 @@ export function UserConstraintEditor({
                                 )}
                             </Group>
                         ))}
-                        <Button
-                            variant="light"
-                            onClick={addTimeRangeEntry}
-                            size="sm"
-                        >
+                        <Button variant="light" onClick={addTimeRangeEntry} size="sm">
                             {resources.labels.addTimeRange}
                         </Button>
                     </Stack>
@@ -457,10 +732,7 @@ export function UserConstraintEditor({
                     <Button variant="subtle" onClick={onClose} disabled={loading}>
                         {resources.cancelButton}
                     </Button>
-                    <Button
-                        type="submit"
-                        loading={loading}
-                    >
+                    <Button type="submit" loading={loading}>
                         {initialData ? resources.updateButton : resources.createButton}
                     </Button>
                 </Group>

--- a/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
+++ b/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
@@ -9,6 +9,9 @@ import { useSchedulingPeriods } from "@/modules/schedule/src/hooks";
 
 import resources from "../constraints-page.resources.json";
 import {
+    getDateFromIsoWeek,
+    getIsoWeekNumber,
+    getWeekdayFromDateKey,
     parseForbiddenTimeRange,
     parsePreferredTimeRange,
     parsePreferredWeekdays,
@@ -48,63 +51,6 @@ interface UserConstraintEditorProps {
 }
 
 const weekdays = resources.other.weekdays;
-
-function normalizeWeekday(weekday: string) {
-    if (!weekday) {
-        return weekday;
-    }
-
-    return weekday.charAt(0).toUpperCase() + weekday.slice(1).toLowerCase();
-}
-
-function createDateKey(date: Date) {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}-${month}-${day}`;
-}
-
-function getWeekdayFromDateKey(dateKey: string) {
-    if (!dateKey) {
-        return "";
-    }
-
-    const [year, month, day] = dateKey.split("-").map(Number);
-    const date = new Date(year, month - 1, day);
-    return weekdays[date.getDay()] || "";
-}
-
-function getIsoWeekNumber(dateKey: string) {
-    const [year, month, day] = dateKey.split("-").map(Number);
-    const date = new Date(year, month - 1, day);
-    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    const dayNumber = (utcDate.getUTCDay() + 6) % 7;
-    utcDate.setUTCDate(utcDate.getUTCDate() - dayNumber + 3);
-
-    const firstThursday = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 4));
-    const firstThursdayDayNumber = (firstThursday.getUTCDay() + 6) % 7;
-    firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNumber + 3);
-
-    return 1 + Math.round((utcDate.getTime() - firstThursday.getTime()) / 604800000);
-}
-
-function getDateFromIsoWeek(year: number, weekNum: number, weekday: string) {
-    const normalizedWeekday = normalizeWeekday(weekday);
-    const weekdayIndex = weekdays.indexOf(normalizedWeekday);
-    if (weekdayIndex < 0) {
-        return "";
-    }
-
-    const week1Thursday = new Date(Date.UTC(year, 0, 4));
-    const week1ThursdayDayNumber = (week1Thursday.getUTCDay() + 6) % 7;
-    week1Thursday.setUTCDate(week1Thursday.getUTCDate() - week1ThursdayDayNumber + 3);
-
-    const isoWeekdayOffset = (weekdayIndex + 6) % 7;
-    const date = new Date(week1Thursday);
-    date.setUTCDate(week1Thursday.getUTCDate() + (weekNum - 1) * 7 + isoWeekdayOffset - 3);
-
-    return createDateKey(new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-}
 
 function createEmptyTimeRangeEntry(): ForbiddenTimeRangeEntry & { id: string } {
     return {
@@ -183,7 +129,7 @@ function serializeConstraintValue(
             return {
                 serializedValue: serializeForbiddenTimeRange([
                     {
-                        weekday: getWeekdayFromDateKey(oneTimeDate) || entry?.weekday || "",
+                        weekday: getWeekdayFromDateKey(oneTimeDate, weekdays) || entry?.weekday || "",
                         startTime: entry?.startTime || "",
                         endTime: entry?.endTime || "",
                     },
@@ -322,7 +268,7 @@ export function UserConstraintEditor({
         }
 
         const year = new Date(selectedPeriod.fromDate).getFullYear();
-        setOneTimeDate(getDateFromIsoWeek(year, initialData.weekNum!, firstEntry.weekday));
+        setOneTimeDate(getDateFromIsoWeek(year, initialData.weekNum!, firstEntry.weekday, weekdays));
     }, [opened, initialData, isOneTimeForbiddenEdit, schedulingPeriods, oneTimeDate]);
 
     const initializeNewData = () => {
@@ -569,7 +515,7 @@ export function UserConstraintEditor({
                                     {
                                         ...firstEntry,
                                         weekday: nextMode === "oneTime" && oneTimeDate
-                                            ? getWeekdayFromDateKey(oneTimeDate)
+                                            ? getWeekdayFromDateKey(oneTimeDate, weekdays)
                                             : firstEntry.weekday,
                                     },
                                 ]);
@@ -588,7 +534,7 @@ export function UserConstraintEditor({
                                     setFormErrors({ ...formErrors, oneTimeDate: "" });
                                     setTimeRangeEntries(previousEntries => {
                                         const firstEntry = previousEntries[0] ?? createEmptyTimeRangeEntry();
-                                        return [{ ...firstEntry, weekday: getWeekdayFromDateKey(value) }];
+                                        return [{ ...firstEntry, weekday: getWeekdayFromDateKey(value, weekdays) }];
                                     });
                                 }}
                                 error={formErrors.oneTimeDate}

--- a/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
+++ b/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
@@ -11,6 +11,7 @@ import resources from "../constraints-page.resources.json";
 import {
     getDateFromIsoWeek,
     getIsoWeekNumber,
+    getMinutesFromTime,
     getWeekdayFromDateKey,
     parseForbiddenTimeRange,
     parsePreferredTimeRange,
@@ -59,11 +60,6 @@ function createEmptyTimeRangeEntry(): ForbiddenTimeRangeEntry & { id: string } {
         endTime: "",
         id: `entry-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
     };
-}
-
-function getMinutesFromTime(time: string) {
-    const [hours, minutes] = time.split(":").map(Number);
-    return hours * 60 + minutes;
 }
 
 function isValidTimeRange(entry: Pick<ForbiddenTimeRangeEntry, "startTime" | "endTime">) {

--- a/src/modules/schedule/src/pages/constraints-page/components/user-constraints-panel.tsx
+++ b/src/modules/schedule/src/pages/constraints-page/components/user-constraints-panel.tsx
@@ -10,7 +10,7 @@ import {
     useSchedulingPeriods
 } from "@/modules/schedule/src/hooks";
 
-import { UserConstraintEditor } from "./user-constraint-editor";
+import { UserConstraintEditor } from "./user-constraint-editor.tsx";
 import { formatConstraintValueForDisplay } from "../utils";
 import resources from "../constraints-page.resources.json";
 import styles from "../constraints-page.module.css";
@@ -233,7 +233,7 @@ export function UserConstraintsPanel({ isAdmin, openConfirmation }: UserConstrai
                                     </Badge>
                                 </Table.Td>
                                 <Table.Td>{item.key}</Table.Td>
-                                <Table.Td>{formatConstraintValueForDisplay(item.key, item.value)}</Table.Td>
+                                <Table.Td>{formatConstraintValueForDisplay(item.key, item.value, item.weekNum)}</Table.Td>
                                 <Table.Td>
                                     <div className={styles.actionIcons}>
                                         <ActionIcon variant="subtle" onClick={() => handleEdit(item)}>

--- a/src/modules/schedule/src/pages/constraints-page/components/user-constraints-panel.tsx
+++ b/src/modules/schedule/src/pages/constraints-page/components/user-constraints-panel.tsx
@@ -72,7 +72,8 @@ export function UserConstraintsPanel({ isAdmin, openConfirmation }: UserConstrai
             return {
                 ...item,
                 userName: user ? `${user.firstName} ${user.lastName}` : item.userId,
-                periodName: period ? period.name : item.schedulingPeriodId
+                periodName: period ? period.name : item.schedulingPeriodId,
+                schedulingPeriod: period ? { fromDate: period.fromDate, toDate: period.toDate } : undefined
             };
         });
     }, [userConstraints, userPreferences, users, schedulingPeriods]);
@@ -233,7 +234,7 @@ export function UserConstraintsPanel({ isAdmin, openConfirmation }: UserConstrai
                                     </Badge>
                                 </Table.Td>
                                 <Table.Td>{item.key}</Table.Td>
-                                <Table.Td>{formatConstraintValueForDisplay(item.key, item.value, item.weekNum)}</Table.Td>
+                                <Table.Td>{formatConstraintValueForDisplay(item.key, item.value, item.weekNum, item.schedulingPeriod)}</Table.Td>
                                 <Table.Td>
                                     <div className={styles.actionIcons}>
                                         <ActionIcon variant="subtle" onClick={() => handleEdit(item)}>

--- a/src/modules/schedule/src/pages/constraints-page/constraints-page.resources.json
+++ b/src/modules/schedule/src/pages/constraints-page/constraints-page.resources.json
@@ -43,6 +43,8 @@
         "lecturer": "Lecturer",
         "actions": "Actions",
         "weekday": "Weekday",
+        "constraintMode": "Constraint Mode",
+        "date": "Date",
         "startTime": "Start Time",
         "endTime": "End Time",
         "minCapacity": "Minimum Capacity",
@@ -58,6 +60,7 @@
         "selectSubject": "Select subject",
         "selectActivity": "Select activity",
         "selectWeekday": "Select weekday",
+        "selectDate": "Select date",
         "selectStartTime": "Select start time",
         "selectEndTime": "Select end time",
         "enterMinCapacity": "Enter minimum capacity",
@@ -99,6 +102,8 @@
         "startTimeBeforeEndTime": "Start time must be before end time",
         "atLeastOneTimeRange": "At least one time range is required",
         "atLeastOneWeekday": "At least one weekday is required",
+        "oneTimeDateRequired": "Date is required for one-time constraints",
+        "oneTimeDateOutOfRange": "Date must be within the selected scheduling period",
         "atLeastOneLocation": "At least one location is required",
         "atLeastOneResourceType": "At least one room type is required",
         "minOrMaxRequired": "At least one of minimum or maximum capacity is required",
@@ -109,6 +114,16 @@
         "invalidLocationPreference": "Invalid format. Expected comma-separated location names (e.g., 'Building A,Building B')",
         "invalidCompatibleResourceTypes": "Invalid format. Expected comma-separated room type names (e.g., 'Lecture Hall,Seminar Room')"
     },
+    "constraintModes": [
+        {
+            "value": "repeated",
+            "label": "Repeated"
+        },
+        {
+            "value": "oneTime",
+            "label": "One Time"
+        }
+    ],
     "constraintTypeOptions": {
         "userConstraints": [
             {
@@ -143,6 +158,7 @@
     },
     "valueFormatGuidance": {
         "forbidden_timerange": "Format: 'Weekday HH:mm - HH:mm' (e.g., 'Monday 09:30 - 11:00'). Multiple entries separated by commas.",
+        "forbidden_timerange_oneTime": "One Time: pick a date and enter a single start/end time.",
         "preferred_weekdays": "Format: Comma-separated weekday names (e.g., 'Monday,Wednesday,Friday')",
         "preferred_timerange": "Format: 'Weekday HH:mm - HH:mm' (e.g., 'Monday 09:30 - 11:00'). Multiple entries separated by commas.",
         "required_capacity": "Format: JSON object with 'min' and/or 'max' (e.g., {\"min\": 30} or {\"min\": 20, \"max\": 50})",

--- a/src/modules/schedule/src/pages/constraints-page/utils/constraint-validation.ts
+++ b/src/modules/schedule/src/pages/constraints-page/utils/constraint-validation.ts
@@ -2,6 +2,11 @@
  * Validation utilities for constraint values
  */
 
+export function getMinutesFromTime(time: string): number {
+    const [hours, minutes] = time.split(":").map(Number);
+    return hours * 60 + minutes;
+}
+
 /**
  * Validates forbidden_timerange format: "Weekday HH:mm - HH:mm"
  * Examples: "Monday 09:30 - 11:00", "Tuesday 13:00-15:00, Wednesday 10:00 - 12:00"
@@ -30,10 +35,8 @@ export function validateForbiddenTimeRange(value: string): string | null {
         }
 
         // Parse times to check if start < end
-        const [startHours, startMinutes] = startTime.split(':').map(Number);
-        const [endHours, endMinutes] = endTime.split(':').map(Number);
-        const startTotal = startHours * 60 + startMinutes;
-        const endTotal = endHours * 60 + endMinutes;
+        const startTotal = getMinutesFromTime(startTime);
+        const endTotal = getMinutesFromTime(endTime);
 
         if (startTotal >= endTotal) {
             return "Start time must be before end time";

--- a/src/modules/schedule/src/pages/constraints-page/utils/constraint-value-formatter.ts
+++ b/src/modules/schedule/src/pages/constraints-page/utils/constraint-value-formatter.ts
@@ -12,14 +12,14 @@ interface SchedulingPeriodRange {
 
 const weekdays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
-function createDateKey(date: Date) {
+export function createDateKey(date: Date) {
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     return `${year}-${month}-${day}`;
 }
 
-function getIsoWeekNumber(dateKey: string) {
+export function getIsoWeekNumber(dateKey: string) {
     const [year, month, day] = dateKey.split("-").map(Number);
     const date = new Date(year, month - 1, day);
     const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -33,12 +33,45 @@ function getIsoWeekNumber(dateKey: string) {
     return 1 + Math.round((utcDate.getTime() - firstThursday.getTime()) / 604800000);
 }
 
-function normalizeWeekday(weekday: string) {
+export function normalizeWeekday(weekday: string) {
     if (!weekday) {
         return weekday;
     }
 
     return weekday.charAt(0).toUpperCase() + weekday.slice(1).toLowerCase();
+}
+
+export function getWeekdayFromDateKey(dateKey: string, weekdayOptions: string[] = weekdays) {
+    if (!dateKey) {
+        return "";
+    }
+
+    const [year, month, day] = dateKey.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    return weekdayOptions[date.getDay()] || "";
+}
+
+export function getDateFromIsoWeek(
+    year: number,
+    weekNum: number,
+    weekday: string,
+    weekdayOptions: string[] = weekdays
+) {
+    const normalizedWeekday = normalizeWeekday(weekday);
+    const weekdayIndex = weekdayOptions.indexOf(normalizedWeekday);
+    if (weekdayIndex < 0) {
+        return "";
+    }
+
+    const week1Thursday = new Date(Date.UTC(year, 0, 4));
+    const week1ThursdayDayNumber = (week1Thursday.getUTCDay() + 6) % 7;
+    week1Thursday.setUTCDate(week1Thursday.getUTCDate() - week1ThursdayDayNumber + 3);
+
+    const isoWeekdayOffset = (weekdayIndex + 6) % 7;
+    const date = new Date(week1Thursday);
+    date.setUTCDate(week1Thursday.getUTCDate() + (weekNum - 1) * 7 + isoWeekdayOffset - 3);
+
+    return createDateKey(new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 }
 
 function findDateKeyForWeekdayInPeriod(

--- a/src/modules/schedule/src/pages/constraints-page/utils/constraint-value-formatter.ts
+++ b/src/modules/schedule/src/pages/constraints-page/utils/constraint-value-formatter.ts
@@ -5,33 +5,112 @@
 
 import { parseForbiddenTimeRange } from "./constraint-value-parser";
 
+interface SchedulingPeriodRange {
+    fromDate: string;
+    toDate: string;
+}
+
+const weekdays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+function createDateKey(date: Date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}
+
+function getIsoWeekNumber(dateKey: string) {
+    const [year, month, day] = dateKey.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    const dayNumber = (utcDate.getUTCDay() + 6) % 7;
+    utcDate.setUTCDate(utcDate.getUTCDate() - dayNumber + 3);
+
+    const firstThursday = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 4));
+    const firstThursdayDayNumber = (firstThursday.getUTCDay() + 6) % 7;
+    firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNumber + 3);
+
+    return 1 + Math.round((utcDate.getTime() - firstThursday.getTime()) / 604800000);
+}
+
+function normalizeWeekday(weekday: string) {
+    if (!weekday) {
+        return weekday;
+    }
+
+    return weekday.charAt(0).toUpperCase() + weekday.slice(1).toLowerCase();
+}
+
+function findDateKeyForWeekdayInPeriod(
+    schedulingPeriod: SchedulingPeriodRange,
+    weekNum: number,
+    weekday: string
+) {
+    const startDate = new Date(schedulingPeriod.fromDate);
+    const endDate = new Date(schedulingPeriod.toDate);
+
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+        return null;
+    }
+
+    const targetWeekday = normalizeWeekday(weekday);
+    const cursor = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+
+    while (cursor <= endDate) {
+        const cursorWeekday = weekdays[cursor.getDay()];
+        if (cursorWeekday === targetWeekday && getIsoWeekNumber(createDateKey(cursor)) === weekNum) {
+            return createDateKey(cursor);
+        }
+
+        cursor.setDate(cursor.getDate() + 1);
+    }
+
+    return null;
+}
+
 /**
  * Formats a constraint value for display in tables
- * For time range constraints, converts UTC to local timezone
- * For other constraints, returns the value as-is
+ * For time range constraints, converts UTC to local timezone.
+ * One-time forbidden time ranges are displayed as actual dates.
+ * For other constraints, returns the value as-is.
  * 
  * @param key - The constraint key (e.g., "forbidden_timerange")
  * @param value - The constraint value from database (in UTC for time ranges)
- * @returns Formatted value for display (in local timezone for time ranges)
+ * @param weekNum - Optional ISO week number used for one-time forbidden time ranges
+ * @param schedulingPeriod - Scheduling period boundaries used to resolve one-time dates
+ * @returns Formatted value for display
  */
-export function formatConstraintValueForDisplay(key: string, value: string, weekNum?: number | null): string {
+export function formatConstraintValueForDisplay(
+    key: string,
+    value: string,
+    weekNum?: number | null,
+    schedulingPeriod?: SchedulingPeriodRange
+): string {
     if (!value?.trim()) {
         return value || "";
     }
 
-    // Handle time range constraints that need UTC to local conversion
     if (key === "forbidden_timerange" || key === "preferred_timerange") {
-        // Parse UTC entries and convert to local timezone
         const localEntries = parseForbiddenTimeRange(value);
-        const weekSuffix = weekNum === null || weekNum === undefined ? "" : ` [W${weekNum}]`;
+        const canShowDate = key === "forbidden_timerange"
+            && weekNum !== null
+            && weekNum !== undefined
+            && schedulingPeriod !== undefined;
 
-        // Format for display (entries are already in local timezone, just format as string)
         return localEntries
-            .filter(e => e.weekday && e.startTime && e.endTime)
-            .map(e => `${e.weekday}${weekSuffix} ${e.startTime} - ${e.endTime}`)
+            .filter(entry => entry.weekday && entry.startTime && entry.endTime)
+            .map(entry => {
+                if (canShowDate) {
+                    const dateKey = findDateKeyForWeekdayInPeriod(schedulingPeriod, weekNum, entry.weekday);
+                    if (dateKey) {
+                        return `${dateKey} ${entry.startTime} - ${entry.endTime}`;
+                    }
+                }
+
+                return `${entry.weekday} ${entry.startTime} - ${entry.endTime}`;
+            })
             .join(", ");
     }
 
-    // For other constraint types, return as-is
     return value;
 }

--- a/src/modules/schedule/src/pages/constraints-page/utils/constraint-value-formatter.ts
+++ b/src/modules/schedule/src/pages/constraints-page/utils/constraint-value-formatter.ts
@@ -14,7 +14,7 @@ import { parseForbiddenTimeRange } from "./constraint-value-parser";
  * @param value - The constraint value from database (in UTC for time ranges)
  * @returns Formatted value for display (in local timezone for time ranges)
  */
-export function formatConstraintValueForDisplay(key: string, value: string): string {
+export function formatConstraintValueForDisplay(key: string, value: string, weekNum?: number | null): string {
     if (!value?.trim()) {
         return value || "";
     }
@@ -23,11 +23,12 @@ export function formatConstraintValueForDisplay(key: string, value: string): str
     if (key === "forbidden_timerange" || key === "preferred_timerange") {
         // Parse UTC entries and convert to local timezone
         const localEntries = parseForbiddenTimeRange(value);
+        const weekSuffix = weekNum === null || weekNum === undefined ? "" : ` [W${weekNum}]`;
 
         // Format for display (entries are already in local timezone, just format as string)
         return localEntries
             .filter(e => e.weekday && e.startTime && e.endTime)
-            .map(e => `${e.weekday} ${e.startTime} - ${e.endTime}`)
+            .map(e => `${e.weekday}${weekSuffix} ${e.startTime} - ${e.endTime}`)
             .join(", ");
     }
 


### PR DESCRIPTION
## Description
Adds a one-time mode for forbidden time-range constraints in the schedule UI. Users can now pick a specific date, enter a single time range, and save it as a one-time forbidden constraint. The constraints page also preserves and displays the associated week number so one-time entries can be edited and shown consistently, while the existing repeated forbidden time-range flow remains unchanged.

## Related Issue
Closes #110

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Module(s) Affected
schedule

## Checklist
- [x] My code follows the project contribution rules
- [ ] I used CSS modules (no inline CSS unless necessary)
- [ ] I used absolute imports with @/ prefix
- [x] Display strings are in `*.resources.json` files
- [ ] File and directory names use kebab-case
- [ ] I have added/updated JSDoc comments where appropriate
- [ ] I ran npm run lint with no errors
- [x] I have tested my changes locally

## Screenshots (if applicable)


Additional Notes
This is frontend-only and targets the schedule constraints flow. It introduces a one-time editing path for forbidden time ranges and keeps repeated ranges available as before.