### PR TITLE
[Infra] Root RTL/LTR + language switcher

### DIFF
--- a/src/infra/main.tsx
+++ b/src/infra/main.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter } from "react-router";
 import { MantineProvider } from "@mantine/core";
 import { PrimeReactProvider } from "primereact/api";
 import { theme } from "./theme";
-import { useThemeStore } from "./theme/state";
+import { useLocaleStore, useThemeStore } from "./theme/state";
 import App from "./App";
 import "@mantine/core/styles.css";
 import "primereact/resources/primereact.min.css";
@@ -13,6 +13,8 @@ import "./theme/primereact-overrides.css";
 
 const ThemedApp = () => {
     const colorScheme = useThemeStore((state) => state.colorScheme);
+    const language = useLocaleStore((state) => state.language);
+    const direction = useLocaleStore((state) => state.direction);
 
     useEffect(() => {
         // Dynamically load PrimeReact theme - hacky we store this locally instead of using the npm package, need to update on builds...
@@ -34,7 +36,12 @@ const ThemedApp = () => {
             document.head.appendChild(link);
         }
     }, [colorScheme]);
-
+    
+    useEffect(() => {
+        document.documentElement.setAttribute("lang", language);
+        document.documentElement.setAttribute("dir", direction);
+    }, [language, direction]);
+    
     return (
         <MantineProvider theme={theme} forceColorScheme={colorScheme}>
             <PrimeReactProvider>

--- a/src/infra/theme/components/language-switcher/index.ts
+++ b/src/infra/theme/components/language-switcher/index.ts
@@ -1,0 +1,1 @@
+export * from "./language-switcher";

--- a/src/infra/theme/components/language-switcher/language-switcher.resources.json
+++ b/src/infra/theme/components/language-switcher/language-switcher.resources.json
@@ -1,0 +1,11 @@
+{
+    "interfaceLanguage": "Interface language",
+    "aria": {
+        "selectInterfaceLanguage": "Select interface language",
+        "switchInterfaceLanguage": "Switch interface language"
+    },
+    "languageLabels": {
+        "en": "English",
+        "he": "Hebrew"
+    }
+}

--- a/src/infra/theme/components/language-switcher/language-switcher.tsx
+++ b/src/infra/theme/components/language-switcher/language-switcher.tsx
@@ -1,0 +1,48 @@
+import { Button, SegmentedControl, Stack, Text } from "@mantine/core";
+import { type Language, useLocaleStore } from "@/infra/theme/state";
+import resources from "./language-switcher.resources.json";
+
+type LanguageSwitcherVariant = "compact" | "settings";
+
+interface LanguageSwitcherProps {
+    variant?: LanguageSwitcherVariant;
+}
+
+export const LanguageSwitcher = ({
+    variant = "compact",
+}: LanguageSwitcherProps) => {
+    const language = useLocaleStore((state) => state.language);
+    const setLanguage = useLocaleStore((state) => state.setLanguage);
+    const toggleLanguage = useLocaleStore((state) => state.toggleLanguage);
+
+    if (variant === "compact") {
+        return (
+            <Button
+                variant="default"
+                size="sm"
+                onClick={toggleLanguage}
+                aria-label={resources.aria.switchInterfaceLanguage}
+            >
+                {language.toUpperCase()}
+            </Button>
+        );
+    }
+
+    return (
+        <Stack gap="xs">
+            <Text size="sm" fw={500}>
+                {resources.interfaceLanguage}
+            </Text>
+            <SegmentedControl
+                fullWidth
+                value={language}
+                onChange={(value) => setLanguage(value as Language)}
+                data={[
+                    { label: resources.languageLabels.en, value: "en" },
+                    { label: resources.languageLabels.he, value: "he" },
+                ]}
+                aria-label={resources.aria.selectInterfaceLanguage}
+            />
+        </Stack>
+    );
+};

--- a/src/infra/theme/index.ts
+++ b/src/infra/theme/index.ts
@@ -4,4 +4,5 @@ export { default as DashboardLayout } from "./layouts/dashboard-layout/dashboard
 export { default as PublicLayout } from "./layouts/public-layout/public-layout";
 export * from "./mantine-theme";
 export * from "./state";
+export * from "./components/language-switcher";
 export * from "./components/theme-toggle-button";

--- a/src/infra/theme/layouts/public-layout/public-layout.tsx
+++ b/src/infra/theme/layouts/public-layout/public-layout.tsx
@@ -9,6 +9,7 @@ import {
 import { Outlet } from "react-router";
 import styles from "./public-layout.module.css";
 import PublicLayoutSpecialAction from "./special-action";
+import { LanguageSwitcher } from "@/infra/theme/components/language-switcher";
 import { ThemeToggleButton } from "@/infra/theme/components/theme-toggle-button";
 import { ApplicationNavigationRepository as NavItemsRepo } from "@/infra/federation";
 import { ChronosLogo } from "@/common";
@@ -48,6 +49,7 @@ export default function PublicLayout() {
                         ))}
 
                         <Group gap="sm">
+                            <LanguageSwitcher variant="compact" />
                             <ThemeToggleButton />
                             <PublicLayoutSpecialAction />
                         </Group>

--- a/src/infra/theme/state/index.ts
+++ b/src/infra/theme/state/index.ts
@@ -1,2 +1,3 @@
 /** @author aaron-iz */
+export * from "./locale.store";
 export * from "./theme.store";

--- a/src/infra/theme/state/locale.store.ts
+++ b/src/infra/theme/state/locale.store.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type Language = "en" | "he";
+export type AppDirection = "ltr" | "rtl";
+
+interface LocaleState {
+    language: Language;
+    direction: AppDirection;
+    setLanguage: (language: Language) => void;
+    toggleLanguage: () => void;
+}
+
+const getDirectionByLanguage = (language: Language): AppDirection =>
+    language === "he" ? "rtl" : "ltr";
+
+export const useLocaleStore = create<LocaleState>()(
+    persist(
+        (set, get) => ({
+            language: "en",
+            direction: "ltr",
+            setLanguage: (language: Language) =>
+                set({
+                    language,
+                    direction: getDirectionByLanguage(language),
+                }),
+            toggleLanguage: () => {
+                const nextLanguage: Language =
+                    get().language === "en" ? "he" : "en";
+
+                set({
+                    language: nextLanguage,
+                    direction: getDirectionByLanguage(nextLanguage),
+                });
+            },
+        }),
+        {
+            name: "locale-storage",
+        },
+    ),
+);

--- a/src/modules/auth/src/pages/profile-settings/profile-settings-page.resources.json
+++ b/src/modules/auth/src/pages/profile-settings/profile-settings-page.resources.json
@@ -3,7 +3,11 @@
     "description": "Manage your profile information and account settings",
     "sections": {
         "profileInfo": "Profile Information",
+        "language": "Language",
         "dangerZone": "Danger Zone"
+    },
+    "language": {
+        "description": "Choose interface language and writing direction."
     },
     "dangerZone": {
         "passwordTitle": "Update Password",

--- a/src/modules/auth/src/pages/profile-settings/profile-settings-page.tsx
+++ b/src/modules/auth/src/pages/profile-settings/profile-settings-page.tsx
@@ -8,6 +8,7 @@ import {
     Paper,
     Text,
 } from "@mantine/core";
+import { LanguageSwitcher } from "@/infra/theme/components/language-switcher";
 import { ProfileUpdateForm } from "./components/profile-update-form";
 import { UpdatePasswordModal } from "./components/update-password-modal";
 import resources from "./profile-settings-page.resources.json";
@@ -25,13 +26,24 @@ export function ProfileSettingsPage() {
                 </Text>
                 <Divider className={styles.divider} />
 
-                {/* Profile Information Section */}
                 <Stack gap="lg">
+                    {/* Profile Information Section */}
                     <div>
                         <Title order={2} size="h3" mb="md">
                             {resources.sections.profileInfo}
                         </Title>
                         <ProfileUpdateForm />
+                    </div>
+
+                    {/* Language Section */}
+                    <div>
+                        <Title order={2} size="h3" mb="md">
+                            {resources.sections.language}
+                        </Title>
+                        <Text size="sm" c="dimmed" mb="md">
+                            {resources.language.description}
+                        </Text>
+                        <LanguageSwitcher variant="settings" />
                     </div>
 
                     {/* Danger Zone Section */}


### PR DESCRIPTION
## Description

Implement phase 1 of localization foundation with root-level RTL/LTR automatic direction handling and language switcher UI placement. This PR adds:

- Persisted locale state managing English/Hebrew language selection
- Automatic document `lang`/`dir` synchronization at app root based on selected language
- Reusable language switcher component with compact (header) and settings variants
- Language switcher placement in public header and profile settings page
- All language switcher UI text and aria labels stored in resources files

**Note:** This PR intentionally excludes i18next setup, centralized translation migration, and auto-translation pipeline. Those will follow in phase 2.

## Related Issue

Closes #113 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Module(s) Affected

- `infra` (locale state, language switcher component, root bootstrap wiring, public layout)
- `auth` (profile settings page language section)

## Changes Overview

### Core Implementation
- **`src/infra/theme/state/locale.store.ts`** (new): Zustand store for persisted language + derived direction
- **`src/infra/theme/components/language-switcher/`** (new): Reusable language switcher component with resource-backed labels
- **`src/infra/main.tsx`**: Added effect to sync document `lang` and `dir` attributes from locale store
- **`src/infra/theme/state/index.ts`**: Export locale store
- **`src/infra/theme/index.ts`**: Export language switcher component

### UI Placement
- **`src/infra/theme/layouts/public-layout/public-layout.tsx`**: Add compact language switcher to public header
- **`src/modules/auth/src/pages/profile-settings/profile-settings-page.tsx`**: Add settings language switcher to profile settings page

### Resources
- **`src/infra/theme/components/language-switcher/language-switcher.resources.json`** (new): Language labels and aria text
- **`src/modules/auth/src/pages/profile-settings/profile-settings-page.resources.json`**: Add language section title and description

## Checklist

- [x] My code follows the project contribution rules
- [x] I used CSS modules (no inline CSS unless necessary)
- [x] I used absolute imports with `@/` prefix
- [x] Display strings are in `*.resources.json` files
- [x] File and directory names use kebab-case
- [x] I have added/updated JSDoc comments where appropriate
- [x] I ran `npm run lint` with no errors (no new errors introduced)
- [x] I have tested my changes locally
- [x] Build passes (`npm run build`)

## Behavior & Testing

**Language Direction Switching:**
- Select English: app direction becomes LTR, `<html dir="ltr" lang="en">`
- Select Hebrew: app direction becomes RTL, `<html dir="rtl" lang="he">`
- Direction persists across page refresh and route transitions

**UI Placement:**
- Public pages: compact button in header (labeled with current language code, e.g., "EN" or "HE")
- Profile settings: segmented control with language names below "Interface language" label
- Both controls immediately apply direction and language changes app-wide

**Scope Boundaries:**
- No i18next provider or initialization
- Existing `.resources.json` files in modules remain unchanged (only switcher-specific resources added)
- No auto-translation tooling
- Module navigation labels remain English

## Screenshots (if applicable)

1. Public header with language switcher
<img width="480" height="63" alt="image" src="https://github.com/user-attachments/assets/20458ea6-e85a-49f6-9051-6ee9b4d4be18" />

2. Profile settings page with language section
<img width="903" height="886" alt="image" src="https://github.com/user-attachments/assets/823ac29b-8651-44b4-8b43-eb5dd6a814ed" />

3. App with RTL direction applied (Hebrew selected)
<img width="1891" height="959" alt="image" src="https://github.com/user-attachments/assets/02ef9d06-b527-462e-a847-500dd6125bbe" />

## Additional Notes

- This PR is intentionally scoped to phase 1; follow-up PRs will handle i18next integration and broader content localization.
- The locale store follows the same Zustand + persist pattern as the existing theme store for consistency.
- Language switcher component is reusable and can be placed in other layouts/modules as needed in future phases.
- No changes to module routing or authentication flows.