### PR TITLE
Add i18next localization with build-time translation generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ VITE_API_BASE_URL=http://localhost:5000/
 
 # Discord webhook URL for logging (optional)
 VITE_DISCORD_WEBHOOK_URL=
+
+# Azure Translator settings
+AZURE_TRANSLATOR_KEY=
+AZURE_TRANSLATOR_REGION=
+AZURE_TRANSLATOR_ENDPOINT=https://scheduler-translator.cognitiveservices.azure.com/

--- a/README.md
+++ b/README.md
@@ -59,8 +59,31 @@ You should visit [Chronos.ServiceProxy](https://github.com/bgu-nasa/Chronos.Serv
 1. [Mantine Core](https://mantine.dev/) - As component library
 2. [React Icons](https://react-icons.github.io/react-icons/) - For icons
 3. [React Router](https://reactrouter.com/) - For routing (only for infra, regular contributors should not need to deal with it)
+4. [i18next](https://www.i18next.com/) + [react-i18next](https://react.i18next.com/) - For localization
 
 **TODO:** State management library, some ajax library etc.
+
+## Build-time Translations
+
+All `*.resources.json` files are translated at build time using Azure Translator.
+
+`npm run build` now runs `npm run generate:translations` before TypeScript/Vite build and generates:
+
+- `src/infra/i18n/locales/en/<namespace>/*.generated.json`
+- `src/infra/i18n/locales/he/<namespace>/*.generated.json`
+
+Required environment variables for build:
+
+- `AZURE_TRANSLATOR_KEY`
+- `AZURE_TRANSLATOR_REGION`
+- `AZURE_TRANSLATOR_ENDPOINT`
+
+Example endpoint value: `https://api.cognitive.microsofttranslator.com`
+
+Namespaces follow module/page keys. For example login page resources are generated to:
+
+- `src/infra/i18n/locales/en/auth.login/login-page.generated.json`
+- `src/infra/i18n/locales/he/auth.login/login-page.generated.json`
 
 ## Contribution Rules
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,12 @@
                 "@mantine/hooks": "^8.3.10",
                 "axios": "^1.13.2",
                 "dayjs": "^1.11.19",
+                "dotenv": "^17.4.1",
+                "i18next": "^25.6.0",
                 "primereact": "^10.9.7",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
+                "react-i18next": "^16.2.1",
                 "react-icons": "^5.5.0",
                 "react-router": "^7.10.1",
                 "zustand": "^5.0.9"
@@ -270,9 +273,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -2216,6 +2219,18 @@
                 "csstype": "^3.0.2"
             }
         },
+        "node_modules/dotenv": {
+            "version": "17.4.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+            "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2841,6 +2856,46 @@
                 "hermes-estree": "0.25.1"
             }
         },
+        "node_modules/html-parse-stringify": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+            "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+            "license": "MIT",
+            "dependencies": {
+                "void-elements": "3.1.0"
+            }
+        },
+        "node_modules/i18next": {
+            "version": "25.10.10",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+            "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com/i18next"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2"
+            },
+            "peerDependencies": {
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3348,6 +3403,33 @@
                 "react": "^19.2.3"
             }
         },
+        "node_modules/react-i18next": {
+            "version": "16.6.6",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+            "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2",
+                "html-parse-stringify": "^3.0.1",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "peerDependencies": {
+                "i18next": ">= 25.10.9",
+                "react": ">= 16.8.0",
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-icons": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
@@ -3714,7 +3796,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -3884,6 +3966,15 @@
                 }
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/vite": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
@@ -3957,6 +4048,15 @@
                 "yaml": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/void-elements": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+            "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc -b && vite build",
+        "build": "npm run generate:translations && tsc -b && vite build",
         "lint": "eslint .",
         "preview": "vite preview",
         "create-module": "node scripts/create-module.js",
         "docker:build": "docker build -t chronos-portal .",
         "docker:run": "docker run --env-file .local.env -p 3000:3000 chronos-portal",
-        "docker:start": "npm run docker:build && npm run docker:run"
+        "docker:start": "npm run docker:build && npm run docker:run",
+        "generate:translations": "node scripts/i18n/generate-translations.js"
     },
     "dependencies": {
         "@mantine/core": "^8.3.10",
@@ -19,9 +20,12 @@
         "@mantine/hooks": "^8.3.10",
         "axios": "^1.13.2",
         "dayjs": "^1.11.19",
+        "dotenv": "^17.4.1",
+        "i18next": "^25.6.0",
         "primereact": "^10.9.7",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-i18next": "^16.2.1",
         "react-icons": "^5.5.0",
         "react-router": "^7.10.1",
         "zustand": "^5.0.9"

--- a/scripts/i18n/generate-translations.js
+++ b/scripts/i18n/generate-translations.js
@@ -1,0 +1,274 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import dotenv from "dotenv";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..", "..");
+const outputBaseDir = path.join(projectRoot, "src", "infra", "i18n", "locales");
+
+const requiredEnv = [
+    "AZURE_TRANSLATOR_KEY",
+    "AZURE_TRANSLATOR_REGION",
+    "AZURE_TRANSLATOR_ENDPOINT",
+];
+
+function assertRequiredEnv() {
+    const missing = requiredEnv.filter((name) => !process.env[name]);
+
+    if (missing.length > 0) {
+        throw new Error(
+            `Missing required env vars for translation generation: ${missing.join(", ")}`,
+        );
+    }
+}
+
+function loadLocalEnvironment() {
+    dotenv.config({ path: path.join(projectRoot, ".env") });
+    dotenv.config({ path: path.join(projectRoot, ".env.local"), override: true });
+}
+
+async function findResourceFiles(dirPath) {
+    const entries = await readdir(dirPath, { withFileTypes: true });
+    const result = [];
+
+    for (const entry of entries) {
+        if (entry.name === "node_modules" || entry.name === "dist") {
+            continue;
+        }
+
+        const fullPath = path.join(dirPath, entry.name);
+
+        if (entry.isDirectory()) {
+            const childFiles = await findResourceFiles(fullPath);
+            result.push(...childFiles);
+            continue;
+        }
+
+        if (entry.isFile() && entry.name.endsWith(".resources.json")) {
+            result.push(fullPath);
+        }
+    }
+
+    return result;
+}
+
+function collectStringLeaves(node, pathTokens = []) {
+    if (typeof node === "string") {
+        return [{ pathTokens, value: node }];
+    }
+
+    if (Array.isArray(node)) {
+        return node.flatMap((item, index) =>
+            collectStringLeaves(item, [...pathTokens, index]),
+        );
+    }
+
+    if (node && typeof node === "object") {
+        return Object.entries(node).flatMap(([key, value]) =>
+            collectStringLeaves(value, [...pathTokens, key]),
+        );
+    }
+
+    return [];
+}
+
+function cloneJson(value) {
+    return structuredClone(value);
+}
+
+function setByPath(target, pathTokens, value) {
+    let cursor = target;
+
+    for (let index = 0; index < pathTokens.length - 1; index += 1) {
+        cursor = cursor[pathTokens[index]];
+    }
+
+    cursor[pathTokens[pathTokens.length - 1]] = value;
+}
+
+async function translateToHebrew(texts) {
+    const endpoint = process.env.AZURE_TRANSLATOR_ENDPOINT;
+    const key = process.env.AZURE_TRANSLATOR_KEY;
+    const region = process.env.AZURE_TRANSLATOR_REGION;
+
+    const body = texts.map((text) => ({ Text: text }));
+
+    const endpointBase = endpoint.endsWith("/") ? endpoint : `${endpoint}/`;
+    const candidateUrls = [
+        new URL("translate", endpointBase),
+        new URL("translator/text/v3.0/translate", endpointBase),
+    ];
+
+    for (const candidateUrl of candidateUrls) {
+        candidateUrl.searchParams.set("api-version", "3.0");
+        candidateUrl.searchParams.set("from", "en");
+        candidateUrl.searchParams.set("to", "he");
+    }
+
+    const buildHeaders = (includeRegion) => {
+        const headers = {
+            "Ocp-Apim-Subscription-Key": key,
+            "Content-Type": "application/json",
+            "X-ClientTraceId": randomUUID(),
+        };
+
+        if (includeRegion && region) {
+            headers["Ocp-Apim-Subscription-Region"] = region;
+        }
+
+        return headers;
+    };
+
+    const sendRequest = async (requestUrl, includeRegion) => {
+        return fetch(requestUrl, {
+            method: "POST",
+            headers: buildHeaders(includeRegion),
+            body: JSON.stringify(body),
+        });
+    };
+
+    let lastErrorText = "";
+    let lastStatus = 0;
+    let lastUrl = "";
+
+    for (const candidateUrl of candidateUrls) {
+        lastUrl = candidateUrl.toString();
+        let response = await sendRequest(candidateUrl, true);
+
+        if (response.status === 401 && region) {
+            response = await sendRequest(candidateUrl, false);
+        }
+
+        lastStatus = response.status;
+
+        if (response.ok) {
+            const data = await response.json();
+
+            if (!Array.isArray(data) || data.length !== texts.length) {
+                throw new Error("Unexpected Azure Translator response shape.");
+            }
+
+            return data.map((item) => {
+                const translatedText = item?.translations?.[0]?.text;
+
+                if (typeof translatedText !== "string") {
+                    throw new TypeError(
+                        "Unexpected Azure Translator translation item shape.",
+                    );
+                }
+
+                return translatedText;
+            });
+        }
+
+        lastErrorText = await response.text();
+    }
+
+    throw new Error(
+        `Azure Translator request failed (${lastStatus}) for ${lastUrl}: ${lastErrorText}`,
+    );
+}
+
+function getTranslationNamespaceFromResourcePath(sourceFilePath) {
+    const normalizedPath = path
+        .relative(projectRoot, sourceFilePath)
+        .split(path.sep)
+        .join("/");
+
+    const modulePageMatch = normalizedPath.match(
+        /^src\/modules\/([^/]+)\/src\/pages\/([^/]+)\//,
+    );
+
+    if (modulePageMatch) {
+        return `${modulePageMatch[1]}.${modulePageMatch[2]}`;
+    }
+
+    const moduleMatch = normalizedPath.match(/^src\/modules\/([^/]+)\//);
+
+    if (moduleMatch) {
+        return moduleMatch[1];
+    }
+
+    const filename = path
+        .basename(sourceFilePath)
+        .replace(/\.resources\.json$/, "")
+        .replace(/\.json$/, "");
+
+    return filename;
+}
+
+function getOutputPath(locale, sourceFilePath) {
+    const namespace = getTranslationNamespaceFromResourcePath(sourceFilePath);
+    const generatedFileName = path
+        .basename(sourceFilePath)
+        .replace(/\.resources\.json$/, ".generated.json");
+
+    return path.join(outputBaseDir, locale, namespace, generatedFileName);
+}
+
+async function writeJson(filePath, content) {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${JSON.stringify(content, null, 4)}\n`, "utf8");
+}
+
+async function processResourceFile(resourceFilePath) {
+    const rawContent = await readFile(resourceFilePath, "utf8");
+    const sourceJson = JSON.parse(rawContent);
+    const stringLeaves = collectStringLeaves(sourceJson);
+
+    const outputEnPath = getOutputPath("en", resourceFilePath);
+    const outputHePath = getOutputPath("he", resourceFilePath);
+
+    if (stringLeaves.length === 0) {
+        await Promise.all([
+            writeJson(outputEnPath, sourceJson),
+            writeJson(outputHePath, sourceJson),
+        ]);
+        return;
+    }
+
+    const texts = stringLeaves.map((leaf) => leaf.value);
+    const translatedTexts = await translateToHebrew(texts);
+
+    const enJson = cloneJson(sourceJson);
+    const heJson = cloneJson(sourceJson);
+
+    for (let index = 0; index < stringLeaves.length; index += 1) {
+        const pathTokens = stringLeaves[index].pathTokens;
+        setByPath(enJson, pathTokens, texts[index]);
+        setByPath(heJson, pathTokens, translatedTexts[index]);
+    }
+
+    await Promise.all([
+        writeJson(outputEnPath, enJson),
+        writeJson(outputHePath, heJson),
+    ]);
+}
+
+async function run() {
+    loadLocalEnvironment();
+    assertRequiredEnv();
+
+    const resourceFiles = await findResourceFiles(projectRoot);
+
+    if (resourceFiles.length === 0) {
+        throw new Error("No .resources.json files found in project.");
+    }
+
+    for (const resourceFilePath of resourceFiles) {
+        await processResourceFile(resourceFilePath);
+    }
+
+    console.log(`Generated translation files for ${resourceFiles.length} resources files.`);
+}
+
+try {
+    await run();
+} catch (error) {
+    console.error("Failed to generate translations.");
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+}

--- a/src/infra/i18n/index.ts
+++ b/src/infra/i18n/index.ts
@@ -1,0 +1,182 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+type Language = "en" | "he";
+
+function normalizePath(value: string) {
+    return value
+        .replaceAll("\\", "/")
+        .replace(/^\/+/, "")
+        .replace(/^\.\//, "");
+}
+
+export function getTranslationNamespace(resourceKey: string) {
+    const normalized = normalizePath(resourceKey);
+    const filename = normalized
+        .replace(/\.resources\.json$/, "")
+        .replace(/\.generated\.json$/, "")
+        .replace(/\.json$/, "")
+        .split("/")
+        .pop();
+
+    const modulePageRegex = /^src\/modules\/([^/]+)\/src\/pages\/([^/]+)\//;
+    const modulePageMatch = modulePageRegex.exec(normalized);
+
+    if (modulePageMatch) {
+        return `${modulePageMatch[1]}.${modulePageMatch[2]}.${filename}`;
+    }
+
+    const moduleRegex = /^src\/modules\/([^/]+)\//;
+    const moduleMatch = moduleRegex.exec(normalized);
+
+    if (moduleMatch) {
+        return `${moduleMatch[1]}.${filename}`;
+    }
+
+    return filename ?? normalized;
+}
+
+function namespaceFromGeneratedPath(
+    generatedPath: string,
+    locale: Language,
+): string {
+    const normalizedPath = normalizePath(generatedPath);
+    const match = new RegExp(
+        String.raw`(?:^|/)locales/${locale}/([^/]+)/([^/]+)\.generated\.json$`,
+    ).exec(normalizedPath);
+
+    if (!match) {
+        throw new Error(
+            `Cannot derive translation namespace from generated path: ${generatedPath}`,
+        );
+    }
+
+    const namespaceFolder = match[1];
+    const generatedFileName = match[2];
+
+    return `${namespaceFolder}.${generatedFileName}`;
+}
+
+const englishLocaleFiles = import.meta.glob<Record<string, unknown>>(
+    "./locales/en/**/*.generated.json",
+    {
+        eager: true,
+        import: "default",
+    },
+);
+
+const hebrewLocaleFiles = import.meta.glob<Record<string, unknown>>(
+    "./locales/he/**/*.generated.json",
+    {
+        eager: true,
+        import: "default",
+    },
+);
+
+function loadLocaleResources(locale: Language) {
+    const files = locale === "en" ? englishLocaleFiles : hebrewLocaleFiles;
+
+    return Object.entries(files).reduce<Record<string, Record<string, unknown>>>(
+        (accumulator, [filePath, json]) => {
+            const namespace = namespaceFromGeneratedPath(filePath, locale);
+            accumulator[namespace] = json;
+            return accumulator;
+        },
+        {},
+    );
+}
+
+const resources = {
+    en: loadLocaleResources("en"),
+    he: loadLocaleResources("he"),
+} as const;
+
+function resolveDefaultNamespace() {
+    const englishNamespaces = Object.keys(resources.en);
+
+    if (englishNamespaces.length === 0) {
+        return "translation";
+    }
+
+    const sortedNamespaces = [...englishNamespaces].sort((a, b) =>
+        a.localeCompare(b),
+    );
+
+    return sortedNamespaces.at(0) ?? "translation";
+}
+
+const defaultNamespace = resolveDefaultNamespace();
+
+export function getTranslationKey(resourceKey: string, key: string) {
+    return `${getTranslationNamespace(resourceKey)}:${key}`;
+}
+
+function createTranslatedValue(
+    namespace: string,
+    value: unknown,
+    pathSegments: Array<string | number>,
+): unknown {
+    if (typeof value === "string") {
+        const keyPath = pathSegments.join(".");
+        return i18n.t(`${namespace}:${keyPath}`, { defaultValue: value });
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item, index) =>
+            createTranslatedValue(namespace, item, [...pathSegments, index]),
+        );
+    }
+
+    if (!value || typeof value !== "object") {
+        return value;
+    }
+
+    return new Proxy(value as Record<string, unknown>, {
+        get(target, property) {
+            if (typeof property !== "string") {
+                return Reflect.get(target, property);
+            }
+
+            const nestedValue = target[property];
+            return createTranslatedValue(namespace, nestedValue, [
+                ...pathSegments,
+                property,
+            ]);
+        },
+    });
+}
+
+export function translatedResources<T extends object>(
+    resourceKey: string,
+    fallbackResources: T,
+): T {
+    const namespace = getTranslationNamespace(resourceKey);
+    return createTranslatedValue(namespace, fallbackResources, []) as T;
+}
+
+let hasInitialized = false;
+
+export function initializeI18n(language: Language) {
+    if (hasInitialized) {
+        if (i18n.language !== language) {
+            void i18n.changeLanguage(language);
+        }
+        return i18n;
+    }
+
+    void i18n.use(initReactI18next).init({
+        resources,
+        lng: language,
+        fallbackLng: "en",
+        defaultNS: defaultNamespace,
+        interpolation: {
+            escapeValue: false,
+        },
+    });
+
+    hasInitialized = true;
+
+    return i18n;
+}
+
+export { i18n };

--- a/src/infra/main.tsx
+++ b/src/infra/main.tsx
@@ -6,10 +6,13 @@ import { MantineProvider } from "@mantine/core";
 import { PrimeReactProvider } from "primereact/api";
 import { theme } from "./theme";
 import { useLocaleStore, useThemeStore } from "./theme/state";
+import { i18n, initializeI18n } from "./i18n";
 import App from "./App";
 import "@mantine/core/styles.css";
 import "primereact/resources/primereact.min.css";
 import "./theme/primereact-overrides.css";
+
+initializeI18n("en");
 
 const ThemedApp = () => {
     const colorScheme = useThemeStore((state) => state.colorScheme);
@@ -41,6 +44,10 @@ const ThemedApp = () => {
         document.documentElement.setAttribute("lang", language);
         document.documentElement.setAttribute("dir", direction);
     }, [language, direction]);
+
+    useEffect(() => {
+        void i18n.changeLanguage(language);
+    }, [language]);
     
     return (
         <MantineProvider theme={theme} forceColorScheme={colorScheme}>


### PR DESCRIPTION
This PR introduces i18next localization and build-time translation generation for portal resources.

Highlights:
- Adds i18next/react-i18next and initializes localization at app startup.
- Runs translation generation automatically during npm run build.
- Loads Azure Translator settings from environment variables.
- Migrates the login page to translation keys.
- Adds generated locale files for the current resources.

Verification:
- npm run generate:translations
- npm run build