### PR TITLE
[Schedule] Make calendar rendering week-aware and period-bounded

### DIFF
--- a/src/common/components/calendar/week-view/day-column.tsx
+++ b/src/common/components/calendar/week-view/day-column.tsx
@@ -8,6 +8,7 @@ import type { CalendarEvent } from "@/common/types";
 import { EventItem } from './event-item';
 import { ConstraintItem } from './constraint-item';
 import { EventBlockItem } from './event-block-item';
+import { getIsoWeekNumber } from './iso-week';
 import styles from './day-column.module.css';
 import resources from './day-column.resources.json';
 
@@ -20,9 +21,11 @@ interface ConstraintVisualization {
   weekday: string;
   startTime: string;
   endTime: string;
+  weekNum?: number | null;
 }
 
 interface EventBlock extends ConstraintVisualization {
+  weekNum?: number | null;
   activityId?: string;
   activityType?: string;
   subjectName?: string;
@@ -36,6 +39,8 @@ interface DayColumnProps {
   events: CalendarEvent[];
   constraints?: ConstraintVisualization[];
   eventBlocks?: EventBlock[];
+  periodFromDate?: string;
+  periodToDate?: string;
   hourHeight?: number;
   dayStartHour?: number;
   hoursPerDay?: number;
@@ -48,6 +53,8 @@ export const DayColumn: React.FC<DayColumnProps> = ({
   events,
   constraints = [],
   eventBlocks = [],
+  periodFromDate,
+  periodToDate,
   hourHeight = 60,
   dayStartHour = 8,
   hoursPerDay = 24,
@@ -260,16 +267,60 @@ export const DayColumn: React.FC<DayColumnProps> = ({
 
   // Get weekday name for this column
   const weekdayName = date.toLocaleDateString('en-US', { weekday: 'long' });
+  const weekNum = getIsoWeekNumber(date);
+  const isInsideSelectedPeriod = useMemo(() => {
+    if (!periodFromDate || !periodToDate) {
+      return true;
+    }
+
+    const current = new Date(date);
+    const from = new Date(periodFromDate);
+    const to = new Date(periodToDate);
+
+    current.setHours(0, 0, 0, 0);
+    from.setHours(0, 0, 0, 0);
+    to.setHours(0, 0, 0, 0);
+
+    return current >= from && current <= to;
+  }, [date, periodFromDate, periodToDate]);
 
   // Filter constraints for this weekday
   const dailyConstraints = useMemo(() => {
-    return constraints.filter(c => c.weekday === weekdayName);
-  }, [constraints, weekdayName]);
+    if (!isInsideSelectedPeriod) {
+      return [];
+    }
+
+    return constraints.filter(c => {
+      if (c.weekday !== weekdayName) {
+        return false;
+      }
+
+      if (c.weekNum == null) {
+        return true;
+      }
+
+      return c.weekNum === weekNum;
+    });
+  }, [constraints, weekdayName, weekNum, isInsideSelectedPeriod]);
 
   // Filter event blocks for this weekday
   const dailyEventBlocks = useMemo(() => {
-    return eventBlocks.filter(eb => eb.weekday === weekdayName);
-  }, [eventBlocks, weekdayName]);
+    if (!isInsideSelectedPeriod) {
+      return [];
+    }
+
+    return eventBlocks.filter(eb => {
+      if (eb.weekday !== weekdayName) {
+        return false;
+      }
+
+      if (eb.weekNum == null) {
+        return true;
+      }
+
+      return eb.weekNum === weekNum;
+    });
+  }, [eventBlocks, weekdayName, weekNum, isInsideSelectedPeriod]);
 
   return (
     <Box

--- a/src/common/components/calendar/week-view/iso-week.ts
+++ b/src/common/components/calendar/week-view/iso-week.ts
@@ -1,0 +1,8 @@
+export function getIsoWeekNumber(date: Date): number {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const day = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  return Math.ceil((((utcDate.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+}

--- a/src/common/components/calendar/week-view/time-grid.tsx
+++ b/src/common/components/calendar/week-view/time-grid.tsx
@@ -11,9 +11,11 @@ interface ConstraintVisualization {
   weekday: string;
   startTime: string;
   endTime: string;
+  weekNum?: number | null;
 }
 
 interface EventBlock extends ConstraintVisualization {
+  weekNum?: number | null;
   activityId?: string;
   activityType?: string;
   subjectName?: string;
@@ -27,6 +29,8 @@ interface TimeGridProps {
   events: CalendarEvent[];
   constraints?: ConstraintVisualization[];
   eventBlocks?: EventBlock[];
+  periodFromDate?: string;
+  periodToDate?: string;
   hourHeight?: number;
   dayStartHour?: number;
   hoursPerDay?: number;
@@ -39,6 +43,8 @@ export const TimeGrid: React.FC<TimeGridProps> = ({
   events,
   constraints = [],
   eventBlocks = [],
+  periodFromDate,
+  periodToDate,
   hourHeight,
   dayStartHour = 0,
   hoursPerDay = 24,
@@ -61,6 +67,8 @@ export const TimeGrid: React.FC<TimeGridProps> = ({
             events={events}
             constraints={constraints}
             eventBlocks={eventBlocks}
+            periodFromDate={periodFromDate}
+            periodToDate={periodToDate}
             hourHeight={hourHeight}
             dayStartHour={dayStartHour}
             hoursPerDay={hoursPerDay}

--- a/src/common/components/calendar/week-view/week-view.tsx
+++ b/src/common/components/calendar/week-view/week-view.tsx
@@ -1,5 +1,5 @@
 /** @author noamarg */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Box, Button, Group, Text, Paper } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 
@@ -13,9 +13,11 @@ interface ConstraintVisualization {
   weekday: string;
   startTime: string;
   endTime: string;
+  weekNum?: number | null;
 }
 
 interface EventBlock extends ConstraintVisualization {
+  weekNum?: number | null;
   activityId?: string;
   activityType?: string;
   subjectName?: string;
@@ -29,6 +31,8 @@ interface WeekViewProps {
   events: CalendarEvent[];
   constraints?: ConstraintVisualization[];
   eventBlocks?: EventBlock[];
+  periodFromDate?: string;
+  periodToDate?: string;
   dayStartHour?: number;
   dayEndHour?: number;
   onTimeRangeSelect?: (selection: { date: Date; startTime: string; endTime: string }) => void;
@@ -40,12 +44,18 @@ export const WeekView: React.FC<WeekViewProps> = ({
   events,
   constraints = [],
   eventBlocks = [],
+  periodFromDate,
+  periodToDate,
   dayStartHour = resources.config.defaultStartHour,
   dayEndHour = resources.config.defaultEndHour,
   onTimeRangeSelect,
   onEventBlockClick
 }) => {
   const [currentDate, setCurrentDate] = useState(initialDate);
+
+  useEffect(() => {
+    setCurrentDate(initialDate);
+  }, [initialDate]);
 
   // Calculate dates for the current week (starting Sunday)
   const weekDates = useMemo(() => {
@@ -108,6 +118,8 @@ export const WeekView: React.FC<WeekViewProps> = ({
           events={events}
           constraints={constraints}
           eventBlocks={eventBlocks}
+          periodFromDate={periodFromDate}
+          periodToDate={periodToDate}
           dayStartHour={dayStartHour}
           hoursPerDay={hoursPerDay}
           hourHeight={resources.config.hourHeight || 60}

--- a/src/modules/schedule/src/data/assignment.types.ts
+++ b/src/modules/schedule/src/data/assignment.types.ts
@@ -12,6 +12,7 @@ export interface AssignmentResponse {
     slotId: string;
     resourceId: string;
     activityId: string;
+    weekNum?: number | null;
 }
 
 /**
@@ -21,6 +22,7 @@ export interface CreateAssignmentRequest {
     slotId: string;
     resourceId: string;
     activityId: string;
+    weekNum?: number | null;
 }
 
 /**
@@ -30,4 +32,5 @@ export interface UpdateAssignmentRequest {
     slotId?: string;
     resourceId?: string;
     activityId?: string;
+    weekNum?: number | null;
 }

--- a/src/modules/schedule/src/pages/calendar-page/calendar-page.tsx
+++ b/src/modules/schedule/src/pages/calendar-page/calendar-page.tsx
@@ -36,6 +36,7 @@ export function CalendarPage() {
     weekday: string;
     startTime: string;
     endTime: string;
+    weekNum?: number | null;
     activityId?: string;
     activityType?: string;
     subjectName?: string;
@@ -44,12 +45,36 @@ export function CalendarPage() {
     resourceId?: string;
     expectedStudents?: number | null;
   }
+
+  interface ConstraintVisualization {
+    weekday: string;
+    startTime: string;
+    endTime: string;
+    weekNum?: number | null;
+  }
   const [selectedEvent, setSelectedEvent] = useState<EventBlock | null>(null);
   const [eventModalOpened, setEventModalOpened] = useState(false);
 
   const { createUserConstraint, fetchUserConstraintsByUser, userConstraints, isLoading } = useUserConstraints();
   const { schedulingPeriods, fetchSchedulingPeriods } = useSchedulingPeriods();
   const { fetchUsers } = useUsers();
+
+  const selectedSchedulingPeriod = useMemo(() => {
+    if (!selectedPeriodId) {
+      return null;
+    }
+
+    return schedulingPeriods.find((period) => period.id === selectedPeriodId) ?? null;
+  }, [schedulingPeriods, selectedPeriodId]);
+
+  const initialCalendarDate = useMemo(() => {
+    if (!selectedSchedulingPeriod?.fromDate) {
+      return new Date();
+    }
+
+    const parsed = new Date(selectedSchedulingPeriod.fromDate);
+    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  }, [selectedSchedulingPeriod]);
 
   // Initialize user and admin status
   useEffect(() => {
@@ -166,11 +191,16 @@ export function CalendarPage() {
     );
 
     // Parse and flatten all constraint entries
-    const visualizations: Array<{ weekday: string; startTime: string; endTime: string }> = [];
+    const visualizations: ConstraintVisualization[] = [];
 
     for (const constraint of relevantConstraints) {
       const entries = parseForbiddenTimeRange(constraint.value);
-      visualizations.push(...entries);
+      entries.forEach((entry) => {
+        visualizations.push({
+          ...entry,
+          weekNum: constraint.weekNum ?? null,
+        });
+      });
     }
 
     return visualizations;
@@ -227,6 +257,7 @@ export function CalendarPage() {
             weekday: localSlot.weekday,
             startTime: localSlot.fromTime,
             endTime: localSlot.toTime,
+            weekNum: a.weekNum,
             activityId: a.activityId,
             activityType: activity?.activityType,
             subjectName: subject?.name,
@@ -327,9 +358,12 @@ export function CalendarPage() {
       </Paper>
       <Box className={styles.content}>
         <WeekView
+          initialDate={initialCalendarDate}
           events={[]}
           constraints={constraintVisualizations}
           eventBlocks={eventBlockVisualizations}
+          periodFromDate={selectedSchedulingPeriod?.fromDate}
+          periodToDate={selectedSchedulingPeriod?.toDate}
           onTimeRangeSelect={handleTimeRangeSelect}
           onEventBlockClick={(eventBlock) => {
             setSelectedEvent(eventBlock);


### PR DESCRIPTION
## Description
Adds `WeekNum`-aware rendering and period-bound filtering in week calendar components, plus period-start initialization behavior.

## Related Issue
Closes #121 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Module(s) Affected
common, schedule

## Checklist
- [x] My code follows the project [contribution rules](../README.md#contribution-rules)
- [x] I used CSS modules (no inline CSS unless necessary)
- [x] I used absolute imports with @/ prefix
- [x] Display strings are in *.resources.json files
- [x] File and directory names use kebab-case
- [ ] I have added/updated JSDoc comments where appropriate
- [x] I ran npm run lint with no errors
- [x] I have tested my changes locally

## Screenshots (if applicable)

## Additional Notes
Depends on service `WeekNum` API support for full behavior.