### PR TITLE
[Schedule] Apply UTC contract to slot create/edit/display flows

### DIFF
--- a/src/modules/schedule/src/pages/scheduling-periods-page/components/assignment-panel.tsx
+++ b/src/modules/schedule/src/pages/scheduling-periods-page/components/assignment-panel.tsx
@@ -13,6 +13,7 @@ import { useAssignments, useDeleteAssignment } from "@/modules/schedule/src/hook
 import { useAssignmentEditorStore } from "@/modules/schedule/src/stores/assignment-editor.store";
 import type { SlotResponse } from "@/modules/schedule/src/data/slot.types";
 import type { AssignmentResponse } from "@/modules/schedule/src/data/assignment.types";
+import { convertSlotUtcToLocal } from "@/modules/schedule/src/pages/constraints-page/utils/timezone-utils";
 
 interface AssignmentPanelProps {
     isOpen: boolean;
@@ -20,7 +21,7 @@ interface AssignmentPanelProps {
     onClose: () => void;
 }
 
-export function AssignmentPanel({ isOpen, slot, onClose }: AssignmentPanelProps) {
+export function AssignmentPanel({ isOpen, slot, onClose }: Readonly<AssignmentPanelProps>) {
     const [selectedAssignment, setSelectedAssignment] = useState<AssignmentResponse | null>(null);
 
     const { assignments, isLoading, fetchAssignments, clearAssignments } = useAssignments();
@@ -101,6 +102,18 @@ export function AssignmentPanel({ isOpen, slot, onClose }: AssignmentPanelProps)
         return `${parts[0]}:${parts[1]}`;
     };
 
+    const localSlotHeader = slot
+        ? (convertSlotUtcToLocal(
+            slot.weekday,
+            slot.fromTime.split(":").slice(0, 2).join(":"),
+            slot.toTime.split(":").slice(0, 2).join(":")
+        )[0] ?? {
+            weekday: slot.weekday,
+            fromTime: slot.fromTime,
+            toTime: slot.toTime,
+        })
+        : null;
+
     if (!slot) return null;
 
     return (
@@ -112,7 +125,7 @@ export function AssignmentPanel({ isOpen, slot, onClose }: AssignmentPanelProps)
                     <Stack gap={0}>
                         <Title order={4}>Assignments</Title>
                         <Text size="sm" c="dimmed">
-                            {slot.weekday} • {formatTime(slot.fromTime)} - {formatTime(slot.toTime)}
+                            {localSlotHeader?.weekday} • {formatTime(localSlotHeader?.fromTime ?? "")} - {formatTime(localSlotHeader?.toTime ?? "")}
                         </Text>
                     </Stack>
                 }

--- a/src/modules/schedule/src/pages/scheduling-periods-page/components/slot-editor.tsx
+++ b/src/modules/schedule/src/pages/scheduling-periods-page/components/slot-editor.tsx
@@ -3,6 +3,7 @@ import { Modal, Select, Button, Stack, Text, Group, Chip, Box, ActionIcon } from
 import { useSlotEditorStore } from "@/modules/schedule/src/stores";
 import { useCreateSlot, useUpdateSlot } from "@/modules/schedule/src/hooks";
 import { Weekday, WeekdayOrder } from "@/modules/schedule/src/data";
+import { convertSlotLocalToUtc, convertSlotUtcToLocal } from "@/modules/schedule/src/pages/constraints-page/utils/timezone-utils";
 import resources from "@/modules/schedule/src/pages/scheduling-periods-page/slot.resources.json";
 
 interface SlotEditorProps {
@@ -27,7 +28,7 @@ interface TimeSpinnerProps {
     error?: string;
 }
 
-function TimeSpinner({ label, totalMinutes, onChange, error }: TimeSpinnerProps) {
+function TimeSpinner({ label, totalMinutes, onChange, error }: Readonly<TimeSpinnerProps>) {
     const hours = Math.floor(totalMinutes / 60);
     const minutes = totalMinutes % 60;
 
@@ -93,7 +94,7 @@ const dayOptions = WeekdayOrder.map((day) => ({
     label: day,
 }));
 
-export function SlotEditor({ schedulingPeriodId }: SlotEditorProps) {
+export function SlotEditor({ schedulingPeriodId }: Readonly<SlotEditorProps>) {
     const { isOpen, mode, slot, close } = useSlotEditorStore();
     const { createSlot, clearError: clearCreateError } = useCreateSlot();
     const { updateSlot, clearError: clearUpdateError } = useUpdateSlot();
@@ -145,12 +146,17 @@ export function SlotEditor({ schedulingPeriodId }: SlotEditorProps) {
 
             if (mode === "edit" && slot) {
                 // Edit mode: single slot
-                setEditWeekday(slot.weekday);
-                // Parse time to total minutes
-                const fromParts = slot.fromTime.split(":");
-                const toParts = slot.toTime.split(":");
-                setEditFromTime(parseInt(fromParts[0], 10) * 60 + parseInt(fromParts[1], 10));
-                setEditToTime(parseInt(toParts[0], 10) * 60 + parseInt(toParts[1], 10));
+                const slotFromTime = slot.fromTime.split(':').slice(0, 2).join(':');
+                const slotToTime = slot.toTime.split(':').slice(0, 2).join(':');
+                const localSlots = convertSlotUtcToLocal(slot.weekday, slotFromTime, slotToTime);
+                const localSlot = localSlots[0] ?? { weekday: slot.weekday, fromTime: slotFromTime, toTime: slotToTime };
+
+                setEditWeekday(localSlot.weekday);
+                // Parse local time to total minutes
+                const fromParts = localSlot.fromTime.split(":");
+                const toParts = localSlot.toTime.split(":");
+                setEditFromTime(Number.parseInt(fromParts[0], 10) * 60 + Number.parseInt(fromParts[1], 10));
+                setEditToTime(Number.parseInt(toParts[0], 10) * 60 + Number.parseInt(toParts[1], 10));
             } else {
                 // Create mode: bulk creation
                 setSelectedDays([]);
@@ -171,7 +177,7 @@ export function SlotEditor({ schedulingPeriodId }: SlotEditorProps) {
         // Check if time range is divisible by duration
         if (duration && startTime < endTime) {
             const timeRange = endTime - startTime;
-            const durationMinutes = parseInt(duration);
+            const durationMinutes = Number.parseInt(duration, 10);
             if (timeRange < durationMinutes) {
                 newErrors.duration = "Time range is too short for this duration";
             } else if (timeRange % durationMinutes !== 0) {
@@ -201,75 +207,102 @@ export function SlotEditor({ schedulingPeriodId }: SlotEditorProps) {
         return withSeconds ? `${h}:${m}:00` : `${h}:${m}`;
     };
 
+    const buildUtcSlotsForCreate = (durationMinutes: number) => {
+        const slotsToCreate: { day: Weekday; fromTime: string; toTime: string }[] = [];
+
+        let currentStart = startTime;
+        while (currentStart + durationMinutes <= endTime) {
+            const fromTimeStr = formatTimeStr(currentStart, true);
+            const toTimeStr = formatTimeStr(currentStart + durationMinutes, true);
+
+            selectedDays.forEach((dayStr) => {
+                const utcSlots = convertSlotLocalToUtc(
+                    dayStr,
+                    fromTimeStr.split(":").slice(0, 2).join(":"),
+                    toTimeStr.split(":").slice(0, 2).join(":")
+                );
+
+                utcSlots.forEach((utcSlot) => {
+                    slotsToCreate.push({
+                        day: utcSlot.weekday as Weekday,
+                        fromTime: `${utcSlot.fromTime}:00`,
+                        toTime: `${utcSlot.toTime}:00`,
+                    });
+                });
+            });
+
+            currentStart += durationMinutes;
+        }
+
+        return slotsToCreate;
+    };
+
+    const handleCreateSubmit = async () => {
+        if (!validateCreate()) {
+            return;
+        }
+
+        const durationMinutes = Number.parseInt(duration!, 10);
+        const slotsToCreate = buildUtcSlotsForCreate(durationMinutes);
+
+        let createdCount = 0;
+        for (const slotData of slotsToCreate) {
+            const result = await createSlot({
+                schedulingPeriodId,
+                weekday: slotData.day,
+                fromTime: slotData.fromTime,
+                toTime: slotData.toTime,
+            });
+
+            if (result !== null) {
+                createdCount++;
+            }
+        }
+
+        if (createdCount === slotsToCreate.length) {
+            const pluralSuffix = createdCount === 1 ? "" : "s";
+            $app.notifications.showSuccess("Success", `${createdCount} slot${pluralSuffix} created successfully`);
+        } else {
+            $app.notifications.showError("Error", `Only ${createdCount} of ${slotsToCreate.length} slots were created`);
+        }
+
+        close();
+    };
+
+    const handleEditSubmit = async () => {
+        if (!slot || !validateEdit()) {
+            return;
+        }
+
+        const localFromTime = formatTimeStr(editFromTime, false);
+        const localToTime = formatTimeStr(editToTime, false);
+        const utcSlots = convertSlotLocalToUtc(editWeekday as Weekday, localFromTime, localToTime);
+        const utcSlot = utcSlots[0];
+
+        const success = await updateSlot(slot.id, {
+            weekday: utcSlot.weekday as Weekday,
+            fromTime: `${utcSlot.fromTime}:00`,
+            toTime: `${utcSlot.toTime}:00`,
+        });
+
+        if (success) {
+            $app.notifications.showSuccess("Success", "Slot updated successfully");
+            close();
+            return;
+        }
+
+        $app.notifications.showError("Error", "Failed to update slot");
+    };
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setIsSubmitting(true);
 
         try {
             if (mode === "create") {
-                if (!validateCreate()) {
-                    setIsSubmitting(false);
-                    return;
-                }
-
-                // Generate slots based on time range, duration, and days
-                const durationMinutes = parseInt(duration!);
-
-                const slotsToCreate: { day: Weekday; fromTime: string; toTime: string }[] = [];
-
-                // Generate slot times
-                let currentStart = startTime;
-                while (currentStart + durationMinutes <= endTime) {
-                    const fromTimeStr = formatTimeStr(currentStart, true);
-                    const toTimeStr = formatTimeStr(currentStart + durationMinutes, true);
-
-                    selectedDays.forEach((dayStr) => {
-                        slotsToCreate.push({
-                            day: dayStr as Weekday,
-                            fromTime: fromTimeStr,
-                            toTime: toTimeStr,
-                        });
-                    });
-
-                    currentStart += durationMinutes;
-                }
-
-                // Create all slots
-                let createdCount = 0;
-                for (const slotData of slotsToCreate) {
-                    const result = await createSlot({
-                        schedulingPeriodId,
-                        weekday: slotData.day,
-                        fromTime: slotData.fromTime,
-                        toTime: slotData.toTime,
-                    });
-                    if (result !== null) createdCount++;
-                }
-
-                if (createdCount === slotsToCreate.length) {
-                    $app.notifications.showSuccess("Success", `${createdCount} slot${createdCount !== 1 ? "s" : ""} created successfully`);
-                } else {
-                    $app.notifications.showError("Error", `Only ${createdCount} of ${slotsToCreate.length} slots were created`);
-                }
-                close();
-            } else if (mode === "edit" && slot) {
-                if (!validateEdit()) {
-                    setIsSubmitting(false);
-                    return;
-                }
-
-                const success = await updateSlot(slot.id, {
-                    weekday: editWeekday as Weekday,
-                    fromTime: formatTimeStr(editFromTime, true),
-                    toTime: formatTimeStr(editToTime, true),
-                });
-
-                if (success) {
-                    $app.notifications.showSuccess("Success", "Slot updated successfully");
-                    close();
-                } else {
-                    $app.notifications.showError("Error", "Failed to update slot");
-                }
+                await handleCreateSubmit();
+            } else if (mode === "edit") {
+                await handleEditSubmit();
             }
         } finally {
             setIsSubmitting(false);
@@ -282,7 +315,7 @@ export function SlotEditor({ schedulingPeriodId }: SlotEditorProps) {
     const calculateSlotCount = () => {
         if (!duration || selectedDays.length === 0) return 0;
         if (startTime >= endTime) return 0;
-        return Math.floor((endTime - startTime) / parseInt(duration)) * selectedDays.length;
+        return Math.floor((endTime - startTime) / Number.parseInt(duration, 10)) * selectedDays.length;
     };
 
     return (

--- a/src/modules/schedule/src/pages/scheduling-periods-page/components/slot-table.tsx
+++ b/src/modules/schedule/src/pages/scheduling-periods-page/components/slot-table.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Paper, Text, Group, Stack, Badge } from "@mantine/core";
 import { WeekdayOrder } from "@/modules/schedule/src/data";
 import type { SlotResponse } from "@/modules/schedule/src/data";
+import { convertSlotUtcToLocal } from "@/modules/schedule/src/pages/constraints-page/utils/timezone-utils";
 import resources from "@/modules/schedule/src/pages/scheduling-periods-page/slot.resources.json";
 
 interface SlotTableProps {
@@ -14,10 +15,25 @@ export function SlotTable({
     slots,
     selectedSlot,
     onSelectionChange,
-}: SlotTableProps) {
+}: Readonly<SlotTableProps>) {
+    const localSlotEntries = useMemo(() => {
+        return slots.flatMap((slot) => {
+            const fromTime = slot.fromTime.split(":").slice(0, 2).join(":");
+            const toTime = slot.toTime.split(":").slice(0, 2).join(":");
+            const converted = convertSlotUtcToLocal(slot.weekday, fromTime, toTime);
+
+            return converted.map((entry) => ({
+                slot,
+                weekday: entry.weekday,
+                fromTime: entry.fromTime,
+                toTime: entry.toTime,
+            }));
+        });
+    }, [slots]);
+
     // Group slots by day and sort by time within each day
     const groupedSlots = useMemo(() => {
-        const groups: Record<string, SlotResponse[]> = {};
+        const groups: Record<string, Array<{ slot: SlotResponse; weekday: string; fromTime: string; toTime: string }>> = {};
 
         // Initialize groups for all days
         WeekdayOrder.forEach((day) => {
@@ -25,12 +41,12 @@ export function SlotTable({
         });
 
         // Group slots by weekday
-        slots.forEach((slot) => {
-            const weekday = slot.weekday;
+        localSlotEntries.forEach((slotEntry) => {
+            const weekday = slotEntry.weekday;
             if (!groups[weekday]) {
                 groups[weekday] = [];
             }
-            groups[weekday].push(slot);
+            groups[weekday].push(slotEntry);
         });
 
         // Sort slots within each day by fromTime
@@ -39,7 +55,7 @@ export function SlotTable({
         });
 
         return groups;
-    }, [slots]);
+    }, [localSlotEntries]);
 
     // Format time for display (remove seconds if present)
     const formatTime = (time: string) => {
@@ -67,18 +83,18 @@ export function SlotTable({
                             {day}
                         </Text>
                         <Group gap="xs" wrap="wrap">
-                            {daySlots.map((slot) => (
+                            {daySlots.map((slotEntry) => (
                                 <Badge
-                                    key={slot.id}
+                                    key={`${slotEntry.slot.id}-${slotEntry.weekday}-${slotEntry.fromTime}-${slotEntry.toTime}`}
                                     size="lg"
                                     radius="sm"
-                                    variant={selectedSlot?.id === slot.id ? "filled" : "light"}
+                                    variant={selectedSlot?.id === slotEntry.slot.id ? "filled" : "light"}
                                     onClick={() => onSelectionChange(
-                                        selectedSlot?.id === slot.id ? null : slot
+                                        selectedSlot?.id === slotEntry.slot.id ? null : slotEntry.slot
                                     )}
                                     style={{ cursor: "pointer" }}
                                 >
-                                    {formatTime(slot.fromTime)} - {formatTime(slot.toTime)}
+                                    {formatTime(slotEntry.fromTime)} - {formatTime(slotEntry.toTime)}
                                 </Badge>
                             ))}
                         </Group>


### PR DESCRIPTION
## Description
Converts slot submission to UTC and slot rendering/edit prefill to local time across scheduling period components.

## Related Issue
Closes #123 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Module(s) Affected
schedule

## Checklist
- [x] My code follows the project [contribution rules](../README.md#contribution-rules)
- [x] I used CSS modules (no inline CSS unless necessary)
- [x] I used absolute imports with @/ prefix
- [x] Display strings are in *.resources.json files
- [x] File and directory names use kebab-case
- [ ] I have added/updated JSDoc comments where appropriate
- [x] I ran npm run lint with no errors
- [x] I have tested my changes locally

## Screenshots (if applicable)

## Additional Notes
Includes minor parser file touch from timezone consistency flow.