### PR TITLE
fix(calendar): filter event blocks by period week index

### DIFF
--- a/src/common/components/calendar/week-view/day-column.tsx
+++ b/src/common/components/calendar/week-view/day-column.tsx
@@ -41,6 +41,7 @@ interface DayColumnProps {
   eventBlocks?: EventBlock[];
   periodFromDate?: string;
   periodToDate?: string;
+  periodWeekIndex?: number | null;
   hourHeight?: number;
   dayStartHour?: number;
   hoursPerDay?: number;
@@ -55,6 +56,7 @@ export const DayColumn: React.FC<DayColumnProps> = ({
   eventBlocks = [],
   periodFromDate,
   periodToDate,
+  periodWeekIndex = null,
   hourHeight = 60,
   dayStartHour = 8,
   hoursPerDay = 24,
@@ -318,9 +320,13 @@ export const DayColumn: React.FC<DayColumnProps> = ({
         return true;
       }
 
+      if (periodWeekIndex != null) {
+        return eb.weekNum === periodWeekIndex;
+      }
+
       return eb.weekNum === weekNum;
     });
-  }, [eventBlocks, weekdayName, weekNum, isInsideSelectedPeriod]);
+  }, [eventBlocks, weekdayName, weekNum, periodWeekIndex, isInsideSelectedPeriod]);
 
   return (
     <Box
@@ -363,9 +369,9 @@ export const DayColumn: React.FC<DayColumnProps> = ({
         />
       ))}
 
-      {dailyEventBlocks.map((eventBlock, index) => (
+      {dailyEventBlocks.map((eventBlock) => (
         <EventBlockItem
-          key={`event-block-${index}-${eventBlock.startTime}-${eventBlock.endTime}`}
+          key={`event-block-${eventBlock.activityId ?? 'event'}-${eventBlock.weekNum ?? 'w'}-${eventBlock.startTime}-${eventBlock.endTime}`}
           startTime={eventBlock.startTime}
           endTime={eventBlock.endTime}
           hourHeight={hourHeight}

--- a/src/common/components/calendar/week-view/period-week.ts
+++ b/src/common/components/calendar/week-view/period-week.ts
@@ -1,0 +1,22 @@
+/**
+ * Period-relative week index (1..N), Sunday-start weeks — matches engine PeriodWeekCalculator.
+ */
+export function getSundayWeekStart(date: Date): Date {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  d.setDate(d.getDate() - d.getDay());
+  return d;
+}
+
+export function getPeriodWeekIndex(periodFromDate: string | Date, date: Date): number {
+  const periodFrom =
+    typeof periodFromDate === 'string' ? new Date(periodFromDate) : periodFromDate;
+  const periodStartSunday = getSundayWeekStart(periodFrom);
+  const weekStart = getSundayWeekStart(date);
+  if (weekStart.getTime() < periodStartSunday.getTime()) {
+    return 1;
+  }
+  const days = Math.floor(
+    (weekStart.getTime() - periodStartSunday.getTime()) / (24 * 60 * 60 * 1000)
+  );
+  return Math.floor(days / 7) + 1;
+}

--- a/src/common/components/calendar/week-view/time-grid.tsx
+++ b/src/common/components/calendar/week-view/time-grid.tsx
@@ -31,6 +31,7 @@ interface TimeGridProps {
   eventBlocks?: EventBlock[];
   periodFromDate?: string;
   periodToDate?: string;
+  periodWeekIndex?: number | null;
   hourHeight?: number;
   dayStartHour?: number;
   hoursPerDay?: number;
@@ -45,6 +46,7 @@ export const TimeGrid: React.FC<TimeGridProps> = ({
   eventBlocks = [],
   periodFromDate,
   periodToDate,
+  periodWeekIndex = null,
   hourHeight,
   dayStartHour = 0,
   hoursPerDay = 24,
@@ -69,6 +71,7 @@ export const TimeGrid: React.FC<TimeGridProps> = ({
             eventBlocks={eventBlocks}
             periodFromDate={periodFromDate}
             periodToDate={periodToDate}
+            periodWeekIndex={periodWeekIndex}
             hourHeight={hourHeight}
             dayStartHour={dayStartHour}
             hoursPerDay={hoursPerDay}

--- a/src/common/components/calendar/week-view/week-view.tsx
+++ b/src/common/components/calendar/week-view/week-view.tsx
@@ -6,6 +6,7 @@ import { useHotkeys } from '@mantine/hooks';
 import type { CalendarEvent } from "@/common/types";
 
 import { WeekHeader, TimeGrid } from './';
+import { getPeriodWeekIndex } from './period-week';
 import styles from './week-view.module.css';
 import resources from './week-view.resources.json';
 
@@ -96,6 +97,13 @@ export const WeekView: React.FC<WeekViewProps> = ({
 
   const monthLabel = weekDates[0].toLocaleString('default', { month: 'long', year: 'numeric' });
 
+  const periodWeekIndex = useMemo(() => {
+    if (!periodFromDate || weekDates.length === 0) {
+      return null;
+    }
+    return getPeriodWeekIndex(periodFromDate, weekDates[0]);
+  }, [periodFromDate, weekDates]);
+
   const hoursPerDay = Math.max(1, dayEndHour - dayStartHour);
 
   return (
@@ -120,6 +128,7 @@ export const WeekView: React.FC<WeekViewProps> = ({
           eventBlocks={eventBlocks}
           periodFromDate={periodFromDate}
           periodToDate={periodToDate}
+          periodWeekIndex={periodWeekIndex}
           dayStartHour={dayStartHour}
           hoursPerDay={hoursPerDay}
           hourHeight={resources.config.hourHeight || 60}


### PR DESCRIPTION
## Summary
Aligns calendar week view event blocks with engine period-relative week indices.

Relates to bgu-nasa/main#138

## Test plan
- [x] npm run build
- [x] npm run lint