### PR TITLE
feat(calendar): merge consecutive assignment blocks

### DIFF
--- a/src/common/components/calendar/week-view/day-column.tsx
+++ b/src/common/components/calendar/week-view/day-column.tsx
@@ -41,6 +41,7 @@ interface DayColumnProps {
   eventBlocks?: EventBlock[];
   periodFromDate?: string;
   periodToDate?: string;
+  periodWeekIndex?: number | null;
   hourHeight?: number;
   dayStartHour?: number;
   hoursPerDay?: number;
@@ -55,6 +56,7 @@ export const DayColumn: React.FC<DayColumnProps> = ({
   eventBlocks = [],
   periodFromDate,
   periodToDate,
+  periodWeekIndex = null,
   hourHeight = 60,
   dayStartHour = 8,
   hoursPerDay = 24,
@@ -318,9 +320,13 @@ export const DayColumn: React.FC<DayColumnProps> = ({
         return true;
       }
 
+      if (periodWeekIndex != null) {
+        return eb.weekNum === periodWeekIndex;
+      }
+
       return eb.weekNum === weekNum;
     });
-  }, [eventBlocks, weekdayName, weekNum, isInsideSelectedPeriod]);
+  }, [eventBlocks, weekdayName, weekNum, periodWeekIndex, isInsideSelectedPeriod]);
 
   return (
     <Box
@@ -363,9 +369,9 @@ export const DayColumn: React.FC<DayColumnProps> = ({
         />
       ))}
 
-      {dailyEventBlocks.map((eventBlock, index) => (
+      {dailyEventBlocks.map((eventBlock) => (
         <EventBlockItem
-          key={`event-block-${index}-${eventBlock.startTime}-${eventBlock.endTime}`}
+          key={`event-block-${eventBlock.activityId ?? 'event'}-${eventBlock.weekNum ?? 'w'}-${eventBlock.startTime}-${eventBlock.endTime}`}
           startTime={eventBlock.startTime}
           endTime={eventBlock.endTime}
           hourHeight={hourHeight}

--- a/src/common/components/calendar/week-view/merge-consecutive-event-blocks.ts
+++ b/src/common/components/calendar/week-view/merge-consecutive-event-blocks.ts
@@ -1,0 +1,102 @@
+export interface MergeableEventBlock {
+  weekday?: string;
+  startTime: string;
+  endTime: string;
+  weekNum?: number | null;
+  activityId?: string;
+  activityType?: string;
+  subjectName?: string;
+  assignmentId?: string;
+  slotId?: string;
+  resourceId?: string;
+  expectedStudents?: number | null;
+  assignmentIds?: string[];
+  slotIds?: string[];
+}
+
+function timeToMinutes(time: string): number {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+}
+
+function groupKey(block: MergeableEventBlock): string {
+  const week = block.weekNum ?? 'null';
+  return [
+    block.weekday ?? '',
+    week,
+    block.activityId ?? '',
+    block.resourceId ?? '',
+  ].join('|');
+}
+
+function canMergeAdjacent(previous: MergeableEventBlock, next: MergeableEventBlock): boolean {
+  return previous.endTime === next.startTime;
+}
+
+function mergeSegment(segment: MergeableEventBlock[]): MergeableEventBlock {
+  const first = segment[0];
+  const last = segment[segment.length - 1];
+
+  const assignmentIds = segment
+    .map((b) => b.assignmentId)
+    .filter((id): id is string => Boolean(id));
+  const slotIds = segment
+    .map((b) => b.slotId)
+    .filter((id): id is string => Boolean(id));
+
+  return {
+    ...first,
+    startTime: first.startTime,
+    endTime: last.endTime,
+    assignmentId: first.assignmentId,
+    slotId: first.slotId,
+    assignmentIds: assignmentIds.length > 0 ? assignmentIds : undefined,
+    slotIds: slotIds.length > 0 ? slotIds : undefined,
+  };
+}
+
+/**
+ * Combines consecutive same-activity blocks (e.g. 9–10 and 10–11) into one visual streak.
+ */
+export function mergeConsecutiveEventBlocks<T extends MergeableEventBlock>(blocks: T[]): T[] {
+  if (blocks.length <= 1) {
+    return blocks;
+  }
+
+  const grouped = new Map<string, T[]>();
+  for (const block of blocks) {
+    const key = groupKey(block);
+    const list = grouped.get(key);
+    if (list) {
+      list.push(block);
+    } else {
+      grouped.set(key, [block]);
+    }
+  }
+
+  const merged: T[] = [];
+
+  for (const group of grouped.values()) {
+    const sorted = [...group].sort(
+      (a, b) => timeToMinutes(a.startTime) - timeToMinutes(b.startTime)
+    );
+
+    let segment: T[] = [sorted[0]];
+
+    for (let i = 1; i < sorted.length; i++) {
+      const current = sorted[i];
+      const previous = segment[segment.length - 1];
+
+      if (canMergeAdjacent(previous, current)) {
+        segment.push(current);
+      } else {
+        merged.push(mergeSegment(segment) as T);
+        segment = [current];
+      }
+    }
+
+    merged.push(mergeSegment(segment) as T);
+  }
+
+  return merged;
+}

--- a/src/common/components/calendar/week-view/period-week.ts
+++ b/src/common/components/calendar/week-view/period-week.ts
@@ -1,0 +1,22 @@
+/**
+ * Period-relative week index (1..N), Sunday-start weeks — matches engine PeriodWeekCalculator.
+ */
+export function getSundayWeekStart(date: Date): Date {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  d.setDate(d.getDate() - d.getDay());
+  return d;
+}
+
+export function getPeriodWeekIndex(periodFromDate: string | Date, date: Date): number {
+  const periodFrom =
+    typeof periodFromDate === 'string' ? new Date(periodFromDate) : periodFromDate;
+  const periodStartSunday = getSundayWeekStart(periodFrom);
+  const weekStart = getSundayWeekStart(date);
+  if (weekStart.getTime() < periodStartSunday.getTime()) {
+    return 1;
+  }
+  const days = Math.floor(
+    (weekStart.getTime() - periodStartSunday.getTime()) / (24 * 60 * 60 * 1000)
+  );
+  return Math.floor(days / 7) + 1;
+}

--- a/src/common/components/calendar/week-view/time-grid.tsx
+++ b/src/common/components/calendar/week-view/time-grid.tsx
@@ -31,6 +31,7 @@ interface TimeGridProps {
   eventBlocks?: EventBlock[];
   periodFromDate?: string;
   periodToDate?: string;
+  periodWeekIndex?: number | null;
   hourHeight?: number;
   dayStartHour?: number;
   hoursPerDay?: number;
@@ -45,6 +46,7 @@ export const TimeGrid: React.FC<TimeGridProps> = ({
   eventBlocks = [],
   periodFromDate,
   periodToDate,
+  periodWeekIndex = null,
   hourHeight,
   dayStartHour = 0,
   hoursPerDay = 24,
@@ -69,6 +71,7 @@ export const TimeGrid: React.FC<TimeGridProps> = ({
             eventBlocks={eventBlocks}
             periodFromDate={periodFromDate}
             periodToDate={periodToDate}
+            periodWeekIndex={periodWeekIndex}
             hourHeight={hourHeight}
             dayStartHour={dayStartHour}
             hoursPerDay={hoursPerDay}

--- a/src/common/components/calendar/week-view/week-view.tsx
+++ b/src/common/components/calendar/week-view/week-view.tsx
@@ -6,6 +6,7 @@ import { useHotkeys } from '@mantine/hooks';
 import type { CalendarEvent } from "@/common/types";
 
 import { WeekHeader, TimeGrid } from './';
+import { getPeriodWeekIndex } from './period-week';
 import styles from './week-view.module.css';
 import resources from './week-view.resources.json';
 
@@ -96,6 +97,13 @@ export const WeekView: React.FC<WeekViewProps> = ({
 
   const monthLabel = weekDates[0].toLocaleString('default', { month: 'long', year: 'numeric' });
 
+  const periodWeekIndex = useMemo(() => {
+    if (!periodFromDate || weekDates.length === 0) {
+      return null;
+    }
+    return getPeriodWeekIndex(periodFromDate, weekDates[0]);
+  }, [periodFromDate, weekDates]);
+
   const hoursPerDay = Math.max(1, dayEndHour - dayStartHour);
 
   return (
@@ -120,6 +128,7 @@ export const WeekView: React.FC<WeekViewProps> = ({
           eventBlocks={eventBlocks}
           periodFromDate={periodFromDate}
           periodToDate={periodToDate}
+          periodWeekIndex={periodWeekIndex}
           dayStartHour={dayStartHour}
           hoursPerDay={hoursPerDay}
           hourHeight={resources.config.hourHeight || 60}

--- a/src/modules/schedule/src/pages/calendar-page/calendar-page.resources.json
+++ b/src/modules/schedule/src/pages/calendar-page/calendar-page.resources.json
@@ -20,6 +20,7 @@
             "capacity": "Capacity:",
             "expectedStudents": "Expected Students"
         },
+        "consecutiveSlots": "Spans {count} consecutive slots",
         "unknown": {
             "day": "Unknown Day",
             "subject": "Unknown Subject",

--- a/src/modules/schedule/src/pages/calendar-page/calendar-page.tsx
+++ b/src/modules/schedule/src/pages/calendar-page/calendar-page.tsx
@@ -5,6 +5,7 @@ import { translatedResources } from "@/infra/i18n";
 const resources = translatedResources("src/modules/schedule/src/pages/calendar-page/calendar-page.resources.json", resourcesJson);
 
 import { WeekView } from "@/common/components/calendar";
+import { mergeConsecutiveEventBlocks } from "@/common/components/calendar/week-view/merge-consecutive-event-blocks";
 import { useUsers } from "@/modules/auth/src/hooks";
 import { useUserConstraints, useSchedulingPeriods } from "@/modules/schedule/src/hooks";
 import { serializeForbiddenTimeRange, parseForbiddenTimeRange, type ForbiddenTimeRangeEntry } from "@/modules/schedule/src/pages/constraints-page/utils";
@@ -44,6 +45,8 @@ export function CalendarPage() {
     slotId?: string;
     resourceId?: string;
     expectedStudents?: number | null;
+    assignmentIds?: string[];
+    slotIds?: string[];
   }
 
   interface ConstraintVisualization {
@@ -269,7 +272,7 @@ export function CalendarPage() {
         });
       });
 
-    return userEventBlocks;
+    return mergeConsecutiveEventBlocks(userEventBlocks);
   }, [assignments, activities, slots, subjects, isAdmin, selectedUserId, currentUserId, selectedPeriodId]);
 
   const handleTimeRangeSelect = (selection: { date: Date; startTime: string; endTime: string }) => {

--- a/src/modules/schedule/src/pages/calendar-page/components/event-details-modal.tsx
+++ b/src/modules/schedule/src/pages/calendar-page/components/event-details-modal.tsx
@@ -15,6 +15,7 @@ interface EventBlock {
     slotId?: string;
     resourceId?: string;
     expectedStudents?: number | null;
+    assignmentIds?: string[];
 }
 
 interface EventDetailsModalProps {
@@ -97,6 +98,14 @@ export function EventDetailsModal({
                     <Text>
                         {timeRange}
                     </Text>
+                    {eventBlock.assignmentIds && eventBlock.assignmentIds.length > 1 && (
+                        <Text size="sm" c="dimmed">
+                            {resources.eventDetailsModal.consecutiveSlots.replace(
+                                '{count}',
+                                String(eventBlock.assignmentIds.length)
+                            )}
+                        </Text>
+                    )}
                 </div>
 
                 {eventBlock.expectedStudents !== null && eventBlock.expectedStudents !== undefined && (


### PR DESCRIPTION
## Summary
Merges adjacent same-activity calendar blocks and shows consecutive slot count in event details.

Relates to bgu-nasa/main#139

## Test plan
- [x] npm run build