### PR TITLE
add support for fetching unfinished scheduling periods in scheduling …

### DIFF
--- a/src/modules/schedule/src/data/scheduling-period-data-repository.ts
+++ b/src/modules/schedule/src/data/scheduling-period-data-repository.ts
@@ -47,6 +47,14 @@ export class SchedulingPeriodDataRepository {
         return response;
     }
 
+    async getUnfinishedSchedulingPeriods(): Promise<SchedulingPeriodResponse[]> {
+        const response = await $app.ajax.get<SchedulingPeriodResponse[]>(
+            "/api/schedule/scheduling/periods/unfinished",
+            { headers: this.getHeaders() }
+        );
+        return response;
+    }
+
 
 
     /**

--- a/src/modules/schedule/src/hooks/use-scheduling-periods.ts
+++ b/src/modules/schedule/src/hooks/use-scheduling-periods.ts
@@ -27,6 +27,25 @@ export function useSchedulingPeriods() {
 
 
 /**
+ * Hook for accessing only unfinished scheduling periods (toDate > now)
+ */
+export function useUnfinishedSchedulingPeriods() {
+    const unfinishedSchedulingPeriods = useSchedulingPeriodStore((state) => state.unfinishedSchedulingPeriods);
+    const isLoading = useSchedulingPeriodStore((state) => state.isLoading);
+    const error = useSchedulingPeriodStore((state) => state.error);
+    const fetchUnfinishedSchedulingPeriods = useSchedulingPeriodStore(
+        (state) => state.fetchUnfinishedSchedulingPeriods
+    );
+
+    return {
+        unfinishedSchedulingPeriods,
+        isLoading,
+        error,
+        fetchUnfinishedSchedulingPeriods,
+    };
+}
+
+/**
  * Hook for creating a scheduling period
  */
 export function useCreateSchedulingPeriod() {

--- a/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
+++ b/src/modules/schedule/src/pages/constraints-page/components/user-constraint-editor.tsx
@@ -5,7 +5,7 @@ import { ActionIcon, Button, Group, Modal, MultiSelect, Select, Stack, Text, Tex
 import { TimeInput } from "@mantine/dates";
 
 import { useUsers } from "@/modules/auth/src/hooks";
-import { useSchedulingPeriods } from "@/modules/schedule/src/hooks";
+import { useUnfinishedSchedulingPeriods } from "@/modules/schedule/src/hooks";
 
 import resourcesJson from "../constraints-page.resources.json";
 import { translatedResources } from "@/infra/i18n";
@@ -183,7 +183,7 @@ export function UserConstraintEditor({
 }: UserConstraintEditorProps) {
     useLocaleStore((state) => state.language);
     const { users, fetchUsers } = useUsers();
-    const { schedulingPeriods, fetchSchedulingPeriods } = useSchedulingPeriods();
+    const { unfinishedSchedulingPeriods: schedulingPeriods, fetchUnfinishedSchedulingPeriods: fetchSchedulingPeriods } = useUnfinishedSchedulingPeriods();
 
     const [timeRangeEntries, setTimeRangeEntries] = useState<Array<ForbiddenTimeRangeEntry & { id: string }>>([]);
     const [selectedWeekdays, setSelectedWeekdays] = useState<string[]>([]);

--- a/src/modules/schedule/src/state/scheduling-period.store.ts
+++ b/src/modules/schedule/src/state/scheduling-period.store.ts
@@ -14,11 +14,13 @@ import type {
 interface SchedulingPeriodStore {
     // State
     schedulingPeriods: SchedulingPeriodResponse[];
+    unfinishedSchedulingPeriods: SchedulingPeriodResponse[];
     isLoading: boolean;
     error: string | null;
 
     // Actions
     fetchSchedulingPeriods: () => Promise<void>;
+    fetchUnfinishedSchedulingPeriods: () => Promise<void>;
     createSchedulingPeriod: (
         request: CreateSchedulingPeriodRequest
     ) => Promise<SchedulingPeriodResponse | null>;
@@ -36,6 +38,7 @@ interface SchedulingPeriodStore {
 export const useSchedulingPeriodStore = create<SchedulingPeriodStore>((set, get) => ({
     // Initial state
     schedulingPeriods: [],
+    unfinishedSchedulingPeriods: [],
     isLoading: false,
     error: null,
 
@@ -57,6 +60,27 @@ export const useSchedulingPeriodStore = create<SchedulingPeriodStore>((set, get)
             }
             set({ error: errorMessage, isLoading: false });
             $app.logger.error("Error fetching scheduling periods:", err);
+        }
+    },
+
+    // Fetch only unfinished scheduling periods (toDate > now)
+    fetchUnfinishedSchedulingPeriods: async () => {
+        set({ isLoading: true, error: null });
+        try {
+            const data = await schedulingPeriodDataRepository.getUnfinishedSchedulingPeriods();
+            set({ unfinishedSchedulingPeriods: data, isLoading: false });
+        } catch (err) {
+            let errorMessage = "Failed to fetch unfinished scheduling periods";
+            if (err && typeof err === "object" && "status" in err && "message" in err) {
+                const apiError = err as { status: number; message: string };
+                errorMessage = apiError.status
+                    ? `Error ${apiError.status}: ${apiError.message}`
+                    : apiError.message;
+            } else if (err instanceof Error) {
+                errorMessage = err.message;
+            }
+            set({ error: errorMessage, isLoading: false });
+            $app.logger.error("Error fetching unfinished scheduling periods:", err);
         }
     },
 


### PR DESCRIPTION
## Description

I changed the schedling periods to unfinished so user dont see finnished schedling periods

## Related Issue

Closes #https://github.com/bgu-nasa/main/issues/146

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Module(s) Affected

<!-- List the module(s) this PR touches (e.g. infra, common, your-module-name) -->

## Checklist

- [ ] My code follows the project [contribution rules](../README.md#contribution-rules)
- [ ] I used CSS modules (no inline CSS unless necessary)
- [ ] I used absolute imports with `@/` prefix
- [ ] Display strings are in `*.resources.json` files
- [ ] File and directory names use kebab-case
- [ ] I have added/updated JSDoc comments where appropriate
- [ ] I ran `npm run lint` with no errors
- [ ] I have tested my changes locally

## Screenshots (if applicable)

<img width="550" height="145" alt="{26249A60-27E1-46D4-BA06-546F9A6DCA8C}" src="https://github.com/user-attachments/assets/ba323c9c-6953-4efd-a4ff-2a837f4d95ad" />
