### PR TITLE
bugfix(resources): default Courses page to All Departments and load on mount

### DIFF
--- a/src/common/components/department-select/department-select.tsx
+++ b/src/common/components/department-select/department-select.tsx
@@ -22,9 +22,13 @@ interface DepartmentSelectProps {
     error?: string;
     clearable?: boolean;
     includeDeleted?: boolean; // Whether to show deleted departments
+    includeAllOption?: boolean;
+    allOptionLabel?: string;
     style?: React.CSSProperties;
     className?: string;
 }
+
+export const ALL_DEPARTMENTS = "__all__";
 
 interface DepartmentSelectItemProps
     extends React.ComponentPropsWithoutRef<"div"> {
@@ -60,6 +64,8 @@ export function DepartmentSelect({
     error,
     clearable = true,
     includeDeleted = false,
+    includeAllOption = false,
+    allOptionLabel = "All Departments",
     style,
     className,
 }: DepartmentSelectProps) {
@@ -79,12 +85,16 @@ export function DepartmentSelect({
     }, [includeDeleted]);
 
     // Transform departments to Mantine Select data format
-    const selectData: (ComboboxItem & Partial<DepartmentSelectItemProps>)[] =
-        departments.map((dept) => ({
+    const selectData: (ComboboxItem & Partial<DepartmentSelectItemProps>)[] = [
+        ...(includeAllOption
+            ? [{ value: ALL_DEPARTMENTS, label: allOptionLabel, deleted: false }]
+            : []),
+        ...departments.map((dept) => ({
             value: dept.id,
             label: dept.name,
             deleted: dept.deleted,
-        }));
+        })),
+    ];
 
     return (
         <Select

--- a/src/common/components/department-select/index.ts
+++ b/src/common/components/department-select/index.ts
@@ -1,2 +1,2 @@
-export { DepartmentSelect } from "./department-select";
+export { ALL_DEPARTMENTS, DepartmentSelect } from "./department-select";
 export type { Department } from "./department.types";

--- a/src/infra/i18n/locales/en/resources.subjects-page/subject-creator.generated.json
+++ b/src/infra/i18n/locales/en/resources.subjects-page/subject-creator.generated.json
@@ -1,5 +1,8 @@
 {
     "modalTitle": "Create Course",
+    "departmentLabel": "Department",
+    "departmentPlaceholder": "Select department",
+    "noDepartmentsFound": "No departments found",
     "codeLabel": "Course Code",
     "codePlaceholder": "e.g. CS101",
     "nameLabel": "Course Name",

--- a/src/infra/i18n/locales/en/resources.subjects-page/subjects-page.generated.json
+++ b/src/infra/i18n/locales/en/resources.subjects-page/subjects-page.generated.json
@@ -8,7 +8,8 @@
         "nameLabel": "Course Name",
         "namePlaceholder": "e.g. Operating Systems",
         "clearButton": "Clear Filters",
-        "noDepartmentsFound": "No departments found"
+        "noDepartmentsFound": "No departments found",
+        "allDepartmentsOption": "All Departments"
     },
     "createButton": "Create",
     "editButton": "Edit",

--- a/src/infra/i18n/locales/he/resources.subjects-page/subject-creator.generated.json
+++ b/src/infra/i18n/locales/he/resources.subjects-page/subject-creator.generated.json
@@ -1,5 +1,8 @@
 {
     "modalTitle": "יצירת קורס",
+    "departmentLabel": "המחלקה",
+    "departmentPlaceholder": "בחר מחלקה",
+    "noDepartmentsFound": "לא נמצאו מחלקות",
     "codeLabel": "קוד הקורס",
     "codePlaceholder": "לדוגמה, CS101",
     "nameLabel": "שם הקורס",

--- a/src/infra/i18n/locales/he/resources.subjects-page/subjects-page.generated.json
+++ b/src/infra/i18n/locales/he/resources.subjects-page/subjects-page.generated.json
@@ -8,7 +8,8 @@
         "nameLabel": "שם המסלול",
         "namePlaceholder": "לדוגמה, מערכות הפעלה",
         "clearButton": "פילטרים נקיים",
-        "noDepartmentsFound": "לא נמצאו מחלקות"
+        "noDepartmentsFound": "לא נמצאו מחלקות",
+        "allDepartmentsOption": "כל המחלקות"
     },
     "createButton": "יצור",
     "editButton": "עריכה",

--- a/src/modules/resources/src/pages/subjects-page/components/subject-actions.tsx
+++ b/src/modules/resources/src/pages/subjects-page/components/subject-actions.tsx
@@ -30,21 +30,21 @@ export function SubjectActions({
             </Button>
             <Button 
                 onClick={onEditClick} 
-                disabled={!selectedSubject || !hasDepartmentContext}
+                disabled={!selectedSubject}
                 variant="outline"
             >
                 {resources.editButton}
             </Button>
             <Button 
                 onClick={onDeleteClick} 
-                disabled={!selectedSubject || !hasDepartmentContext}
+                disabled={!selectedSubject}
                 variant="outline"
             >
                 {resources.deleteButton}
             </Button>
             <Button 
                 onClick={onViewActivitiesClick} 
-                disabled={!selectedSubject || !hasDepartmentContext}
+                disabled={!selectedSubject}
                 variant="light"
             >
                 {resources.viewActivitiesButton}

--- a/src/modules/resources/src/pages/subjects-page/components/subject-creator.resources.json
+++ b/src/modules/resources/src/pages/subjects-page/components/subject-creator.resources.json
@@ -1,5 +1,8 @@
 {
     "modalTitle": "Create Course",
+    "departmentLabel": "Department",
+    "departmentPlaceholder": "Select department",
+    "noDepartmentsFound": "No departments found",
     "codeLabel": "Course Code",
     "codePlaceholder": "e.g. CS101",
     "nameLabel": "Course Name",

--- a/src/modules/resources/src/pages/subjects-page/components/subject-creator.tsx
+++ b/src/modules/resources/src/pages/subjects-page/components/subject-creator.tsx
@@ -1,5 +1,6 @@
 import { Modal, TextInput, Button, Stack, Select } from "@mantine/core";
 import { useState, useEffect } from "react";
+import { DepartmentSelect } from "@/common/components/department-select";
 import { schedulingPeriodRepository } from "@/modules/resources/src/data";
 import resourcesJson from "./subject-creator.resources.json";
 import { translatedResources } from "@/infra/i18n";
@@ -17,8 +18,9 @@ const resources = translatedResources(
 interface SubjectCreatorProps {
     opened: boolean;
     onClose: () => void;
-    onSubmit: (data: { code: string; name: string; schedulingPeriodId: string }) => Promise<void>;
+    onSubmit: (data: { code: string; name: string; schedulingPeriodId: string; departmentId?: string }) => Promise<void>;
     loading?: boolean;
+    showDepartmentPicker?: boolean;
 }
 
 export function SubjectCreator({
@@ -26,9 +28,11 @@ export function SubjectCreator({
     onClose,
     onSubmit,
     loading = false,
+    showDepartmentPicker = false,
 }: SubjectCreatorProps) {
     const [code, setCode] = useState("");
     const [name, setName] = useState("");
+    const [departmentId, setDepartmentId] = useState<string | null>(null);
     const [schedulingPeriodId, setSchedulingPeriodId] = useState<string | null>(null);
     const [schedulingPeriods, setSchedulingPeriods] = useState<{ value: string; label: string }[]>([]);
     const [isLoadingPeriods, setIsLoadingPeriods] = useState(false);
@@ -64,23 +68,30 @@ export function SubjectCreator({
     const handleSubmit = async () => {
         $app.logger.info(resources.logger.handleSubmitCalled, { code, name, schedulingPeriodId });
         
-        if (!code.trim() || !name.trim() || !schedulingPeriodId) {
+        if (!code.trim() || !name.trim() || !schedulingPeriodId || (showDepartmentPicker && !departmentId)) {
             $app.logger.warn(resources.logger.validationFailed);
             return;
         }
         
         $app.logger.info(resources.logger.callingOnSubmit);
-        await onSubmit({ code, name, schedulingPeriodId });
+        await onSubmit({
+            code,
+            name,
+            schedulingPeriodId,
+            ...(showDepartmentPicker && departmentId ? { departmentId } : {}),
+        });
         
         $app.logger.info(resources.logger.onSubmitCompleted);
         setCode("");
         setName("");
+        setDepartmentId(null);
         setSchedulingPeriodId(null);
     };
 
     const handleClose = () => {
         setCode("");
         setName("");
+        setDepartmentId(null);
         setSchedulingPeriodId(null);
         onClose();
     };
@@ -93,6 +104,16 @@ export function SubjectCreator({
             centered
         >
             <Stack>
+                {showDepartmentPicker && (
+                    <DepartmentSelect
+                        value={departmentId}
+                        onChange={setDepartmentId}
+                        label={resources.departmentLabel}
+                        placeholder={resources.departmentPlaceholder}
+                        nothingFoundMessage={resources.noDepartmentsFound}
+                        required
+                    />
+                )}
                 <TextInput
                     label={resources.codeLabel}
                     placeholder={resources.codePlaceholder}
@@ -120,7 +141,7 @@ export function SubjectCreator({
                 <Button
                     onClick={handleSubmit}
                     loading={loading}
-                    disabled={!code.trim() || !name.trim() || !schedulingPeriodId || isLoadingPeriods}
+                    disabled={!code.trim() || !name.trim() || !schedulingPeriodId || isLoadingPeriods || (showDepartmentPicker && !departmentId)}
                     fullWidth
                 >
                     {resources.submitButton}

--- a/src/modules/resources/src/pages/subjects-page/components/subject-search.tsx
+++ b/src/modules/resources/src/pages/subjects-page/components/subject-search.tsx
@@ -1,5 +1,5 @@
 import { Button, TextInput, Group, Paper } from "@mantine/core";
-import { DepartmentSelect } from "@/common/components/department-select";
+import { ALL_DEPARTMENTS, DepartmentSelect } from "@/common/components/department-select";
 import { translatedResources } from "@/infra/i18n";
 import { useLocaleStore } from "@/infra/theme/state";
 import { useState, useEffect } from "react";
@@ -9,6 +9,8 @@ const resources = translatedResources(
     "src/modules/resources/src/pages/subjects-page/subjects-page.resources.json",
     subjectsPageResourcesJson,
 );
+
+export { ALL_DEPARTMENTS };
 
 export interface SubjectSearchFilters {
     departmentId: string;
@@ -23,20 +25,18 @@ interface SubjectSearchProps {
 
 export function SubjectSearch({ onSearch, onClear }: SubjectSearchProps) {
     useLocaleStore((state) => state.language);
-    const [departmentId, setDepartmentId] = useState<string>("");
+    const [departmentId, setDepartmentId] = useState<string>(ALL_DEPARTMENTS);
     const [code, setCode] = useState("");
     const [name, setName] = useState("");
 
     // Automatically trigger search when any filter changes
     useEffect(() => {
-        if (departmentId) {
-            onSearch({ departmentId, code, name });
-        }
+        onSearch({ departmentId, code, name });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [departmentId, code, name]);
 
     const handleClear = () => {
-        setDepartmentId("");
+        setDepartmentId(ALL_DEPARTMENTS);
         setCode("");
         setName("");
         onClear();
@@ -48,10 +48,13 @@ export function SubjectSearch({ onSearch, onClear }: SubjectSearchProps) {
                 <div style={{ flex: 1 }}>
                     <DepartmentSelect
                         value={departmentId}
-                        onChange={(value) => setDepartmentId(value || "")}
+                        onChange={(value) => setDepartmentId(value || ALL_DEPARTMENTS)}
                         label={resources.filters.departmentLabel}
                         placeholder={resources.filters.departmentPlaceholder}
                         nothingFoundMessage={resources.filters.noDepartmentsFound}
+                        includeAllOption
+                        allOptionLabel={resources.filters.allDepartmentsOption}
+                        clearable={false}
                     />
                 </div>
                 <TextInput

--- a/src/modules/resources/src/pages/subjects-page/subjects-page.resources.json
+++ b/src/modules/resources/src/pages/subjects-page/subjects-page.resources.json
@@ -8,7 +8,8 @@
         "nameLabel": "Course Name",
         "namePlaceholder": "e.g. Operating Systems",
         "clearButton": "Clear Filters",
-        "noDepartmentsFound": "No departments found"
+        "noDepartmentsFound": "No departments found",
+        "allDepartmentsOption": "All Departments"
     },
     "createButton": "Create",
     "editButton": "Edit",

--- a/src/modules/resources/src/pages/subjects-page/subjects-page.tsx
+++ b/src/modules/resources/src/pages/subjects-page/subjects-page.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router";
 import { ConfirmationDialog, useConfirmation } from "@/common";
 import { SubjectActions } from "./components/subject-actions";
 import { SubjectTable } from "./components/subject-table/subject-table";
-import { SubjectSearch, type SubjectSearchFilters } from "./components/subject-search";
+import { ALL_DEPARTMENTS, SubjectSearch, type SubjectSearchFilters } from "./components/subject-search";
 import { SubjectCreator } from "./components/subject-creator";
 import { SubjectEditor } from "./components/subject-editor";
 import type { SubjectData } from "./components/subject-table/types";
@@ -19,12 +19,6 @@ import resourcesJson from "./subjects-page.resources.json";
 import styles from "./subjects-page.module.css";
 import { schedulingPeriodRepository, departmentRepository } from "@/modules/resources/src/data";
 import { translatedResources } from "@/infra/i18n";
-import notificationResourcesJson from "@/infra/service/notification/notification.resources.json";
-
-const notificationResources = translatedResources(
-    "src/infra/service/notification/notification.resources.json",
-    notificationResourcesJson,
-);
 
 const resources = translatedResources("src/modules/resources/src/pages/subjects-page/subjects-page.resources.json", resourcesJson);
 
@@ -38,6 +32,7 @@ export function SubjectsPage() {
     const [codeFilter, setCodeFilter] = useState<string>("");
     const [nameFilter, setNameFilter] = useState<string>("");
     const [schedulingPeriods, setSchedulingPeriods] = useState<Map<string, string>>(new Map());
+    const [departmentsMap, setDepartmentsMap] = useState<Map<string, string>>(new Map());
     
     const { subjects, fetchSubjects, setCurrentDepartment } = useSubjects();
     const { createSubject, isLoading: isCreating } = useCreateSubject();
@@ -52,7 +47,7 @@ export function SubjectsPage() {
         isLoading: isDeleting,
     } = useConfirmation();
 
-    // Fetch scheduling periods on mount
+    // Fetch scheduling periods and build departments map on mount
     useEffect(() => {
         const loadSchedulingPeriods = async () => {
             try {
@@ -65,43 +60,49 @@ export function SubjectsPage() {
             }
         };
         loadSchedulingPeriods();
+
+        const org = $app.organization.getOrganization();
+        if (org?.departments) {
+            const deptsMap = new Map(
+                org.departments.filter((d) => !d.deleted).map((d) => [d.id, d.name])
+            );
+            setDepartmentsMap(deptsMap);
+        }
     }, []);
 
     const handleSearch = async (filters: SubjectSearchFilters) => {
-        // TODO: Backend endpoint needed for filtered search
-        // Expected endpoint: GET /api/department/{departmentId}/resources/subjects/subject
-        // Query params: ?code={code}&name={name}
-        
-        if (!filters.departmentId) {
-            $app.logger.warn(resources.logger.departmentIdRequired);
-            $app.notifications.showWarning(
-                notificationResources.warningTitle,
-                resources.notifications.departmentRequired
-            );
-            return;
+        const isAllDepartments = filters.departmentId === ALL_DEPARTMENTS;
+
+        if (isAllDepartments) {
+            setCurrentDepartmentId(ALL_DEPARTMENTS);
+            setCurrentDepartmentName(null);
+
+            const org = $app.organization.getOrganization();
+            const apiDepartmentId = org?.departments?.find((d) => !d.deleted)?.id;
+            if (!apiDepartmentId) {
+                return;
+            }
+            setCurrentDepartment(apiDepartmentId);
+        } else {
+            try {
+                const department = await departmentRepository.getById(filters.departmentId);
+                setCurrentDepartmentName(department.name);
+                $app.logger.info(resources.logger.fetchedDepartment, { id: department.id, name: department.name });
+            } catch (error) {
+                $app.logger.error(resources.logger.errorFetchingDepartment, error);
+                setCurrentDepartmentName(resources.unknownDepartment);
+            }
+
+            setCurrentDepartmentId(filters.departmentId);
+            setCurrentDepartment(filters.departmentId);
         }
 
-        // Fetch department name
-        try {
-            const department = await departmentRepository.getById(filters.departmentId);
-            setCurrentDepartmentName(department.name);
-            $app.logger.info(resources.logger.fetchedDepartment, { id: department.id, name: department.name });
-        } catch (error) {
-            $app.logger.error(resources.logger.errorFetchingDepartment, error);
-            setCurrentDepartmentName(resources.unknownDepartment);
-        }
-
-        setCurrentDepartmentId(filters.departmentId);
-        setCurrentDepartment(filters.departmentId);
         setCodeFilter(filters.code);
         setNameFilter(filters.name);
         fetchSubjects();
     };
 
     const handleClearFilters = () => {
-        // Reset all state - clear department context and selected subject
-        setCurrentDepartmentId(null);
-        setCurrentDepartmentName(null);
         setCodeFilter("");
         setNameFilter("");
         setSelectedSubject(null);
@@ -111,11 +112,12 @@ export function SubjectsPage() {
         setCreateModalOpened(true);
     };
 
-    const handleCreateSubmit = async (data: { code: string; name: string; schedulingPeriodId: string }) => {
+    const handleCreateSubmit = async (data: { code: string; name: string; schedulingPeriodId: string; departmentId?: string }) => {
         $app.logger.info(resources.logger.handleCreateSubmitCalled, data);
         $app.logger.info(resources.logger.currentDepartmentId, currentDepartmentId);
-        
-        if (!currentDepartmentId) {
+
+        const departmentId = data.departmentId ?? (currentDepartmentId !== ALL_DEPARTMENTS ? currentDepartmentId : null);
+        if (!departmentId) {
             $app.logger.error(resources.logger.noDepartmentIdSet);
             return;
         }
@@ -130,7 +132,7 @@ export function SubjectsPage() {
 
         const request = {
             organizationId: org.id,
-            departmentId: currentDepartmentId,
+            departmentId,
             schedulingPeriodId: data.schedulingPeriodId,
             code: data.code,
             name: data.name,
@@ -164,7 +166,15 @@ export function SubjectsPage() {
         $app.logger.info(resources.logger.selectedSubject, selectedSubject);
         $app.logger.info(resources.logger.currentDepartmentId, currentDepartmentId);
         
-        if (!selectedSubject || !currentDepartmentId) {
+        if (!selectedSubject) {
+            $app.logger.error(resources.logger.missingSubjectOrDepartment);
+            return;
+        }
+
+        const departmentId = currentDepartmentId === ALL_DEPARTMENTS
+            ? selectedSubject.departmentId
+            : currentDepartmentId;
+        if (!departmentId) {
             $app.logger.error(resources.logger.missingSubjectOrDepartment);
             return;
         }
@@ -179,7 +189,7 @@ export function SubjectsPage() {
 
         const request: UpdateSubjectRequest = {
             organizationId: org.id,
-            departmentId: currentDepartmentId,
+            departmentId,
             schedulingPeriodId: data.schedulingPeriodId,
             code: data.code,
             name: data.name,
@@ -223,39 +233,42 @@ export function SubjectsPage() {
     };
 
     const handleViewActivitiesClick = () => {
-        if (selectedSubject && currentDepartmentId) {
+        if (!selectedSubject) return;
+
+        const departmentId = currentDepartmentId === ALL_DEPARTMENTS
+            ? selectedSubject.departmentId
+            : currentDepartmentId;
+        if (departmentId) {
             navigate(
-                `/resources/activities?subjectId=${selectedSubject.id}&departmentId=${currentDepartmentId}`
+                `/resources/activities?subjectId=${selectedSubject.id}&departmentId=${departmentId}`
             );
         }
     };
 
-    // Convert SubjectResponse to SubjectData with display names
-    // Only show subjects if department context is set
-    // Filter subjects by department ID, code, and name
+    const isAllDepartments = currentDepartmentId === ALL_DEPARTMENTS;
+
     const subjectData: SubjectData[] = currentDepartmentId
         ? subjects
             .filter((subject) => {
-                // Filter by department
-                if (subject.departmentId !== currentDepartmentId) return false;
-                
-                // Filter by code if specified
+                if (!isAllDepartments && subject.departmentId !== currentDepartmentId) return false;
+
                 if (codeFilter && !subject.code.toLowerCase().includes(codeFilter.toLowerCase())) {
                     return false;
                 }
-                
-                // Filter by name if specified
+
                 if (nameFilter && !subject.name.toLowerCase().includes(nameFilter.toLowerCase())) {
                     return false;
                 }
-                
+
                 return true;
             })
              .map((subject) => ({
                  id: subject.id,
                  code: subject.code,
                  name: subject.name,
-                 departmentName: currentDepartmentName || resources.loadingText,
+                 departmentName: isAllDepartments
+                     ? departmentsMap.get(subject.departmentId) || resources.unknownDepartment
+                     : currentDepartmentName || resources.loadingText,
                  schedulingPeriodName: schedulingPeriods.get(subject.schedulingPeriodId) || resources.unknownText,
                  departmentId: subject.departmentId,
                  schedulingPeriodId: subject.schedulingPeriodId,
@@ -293,6 +306,7 @@ export function SubjectsPage() {
                     onClose={() => setCreateModalOpened(false)}
                     onSubmit={handleCreateSubmit}
                     loading={isCreating}
+                    showDepartmentPicker={isAllDepartments}
                 />
 
                 <SubjectEditor

--- a/src/modules/resources/src/state/subject.store.ts
+++ b/src/modules/resources/src/state/subject.store.ts
@@ -76,12 +76,11 @@ export const useSubjectStore = create<SubjectStore>((set, get) => ({
         $app.logger.info("[SubjectStore] createSubject called");
         set({ isLoading: true, error: null });
         try {
-            const departmentId = get().getDepartmentId();
-            $app.logger.info("[SubjectStore] Department ID:", departmentId);
+            $app.logger.info("[SubjectStore] Department ID:", request.departmentId);
             $app.logger.info("[SubjectStore] Request:", JSON.stringify(request, null, 2));
             
             const newSubject = await subjectDataRepository.createSubject(
-                departmentId,
+                request.departmentId,
                 request
             );
             
@@ -115,11 +114,10 @@ export const useSubjectStore = create<SubjectStore>((set, get) => ({
         
         set({ isLoading: true, error: null });
         try {
-            const departmentId = get().getDepartmentId();
-            $app.logger.info("[SubjectStore] Department ID:", departmentId);
+            $app.logger.info("[SubjectStore] Department ID:", request.departmentId);
             
             await subjectDataRepository.updateSubject(
-                departmentId,
+                request.departmentId,
                 subjectId,
                 request
             );


### PR DESCRIPTION
## Summary

Improves the Courses (`/resources/subjects`) page so users land on **All Departments** and see courses immediately, without having to pick a department first. Adds all-mode support for search, display, and CRUD while keeping department-scoped API behavior intact.

## Changes

### `DepartmentSelect` (shared)

- Added `includeAllOption` and `allOptionLabel` props.
- Exported `ALL_DEPARTMENTS` sentinel (`"__all__"`) from the component and its barrel export.

### `SubjectSearch`

- Defaults department filter to `ALL_DEPARTMENTS`.
- Enables `includeAllOption` on `DepartmentSelect`.
- Triggers search automatically on mount and when filters change (existing `useEffect` behavior).
- Clear resets department back to All Departments.

### `SubjectsPage`

- Handles all-mode in `handleSearch`: fetches subjects via a department anchor while tracking all-mode in UI state.
- Builds a `departmentsMap` from organization context for department name display.
- Client-side filtering: in all-mode, shows subjects from all departments; in single-department mode, filters by `departmentId`.
- Shows department column names from the map when in all-mode.
- Create flow: requires `departmentId` from the creator modal when in all-mode.
- Edit / View Groups: resolves `departmentId` from the selected row when in all-mode.

### `SubjectCreator` & `SubjectActions`

- `SubjectCreator` accepts `showDepartmentPicker`; renders `DepartmentSelect` when creating in all-mode.
- `SubjectActions` passes through all-mode props for create behavior.

### `subject.store`

- `createSubject` and `updateSubject` now pass `request.departmentId` to the repository instead of the store’s ambient department context.

### i18n

- Added `allDepartmentsOption` and creator department labels in English and Hebrew resource files.

## Test plan

- [ ] Open `/resources/subjects` — verify **All Departments** is selected and courses load without interaction.
- [ ] Confirm the Department column appears and shows correct names in all-mode.
- [ ] Filter by code and name in all-mode — verify client-side filtering works.
- [ ] Switch to a single department — verify only that department’s courses appear.
- [ ] Create a course in all-mode — verify department picker is required and the course appears under the chosen department.
- [ ] Edit a course selected in all-mode — verify update succeeds.
- [ ] Delete a course selected in all-mode — verify delete succeeds.
- [ ] Click **View Groups** from a row in all-mode — verify navigation includes the correct `departmentId`.
- [ ] Click **Clear Filters** — verify department resets to All Departments and the full list reloads.
- [ ] Switch locale to Hebrew — verify new strings render correctly.

## Files changed

| Area | Files |
|------|-------|
| Shared component | `src/common/components/department-select/department-select.tsx`, `index.ts` |
| Subjects page | `subjects-page.tsx`, `subject-search.tsx`, `subject-actions.tsx`, `subject-creator.tsx` |
| State | `src/modules/resources/src/state/subject.store.ts` |
| i18n | `subjects-page` and `subject-creator` resource JSON (en + he) |
