### PR TITLE
Make assignment week number optional in add/edit assignment UI

### DIFF
--- a/src/modules/schedule/src/data/assignment.types.ts
+++ b/src/modules/schedule/src/data/assignment.types.ts
@@ -12,7 +12,7 @@ export interface AssignmentResponse {
     slotId: string;
     resourceId: string;
     activityId: string;
-    weekNum: number;
+    weekNum: number | null;
 }
 
 /**
@@ -22,7 +22,7 @@ export interface CreateAssignmentRequest {
     slotId: string;
     resourceId: string;
     activityId: string;
-    weekNum: number;
+    weekNum?: number | null;
 }
 
 /**
@@ -32,5 +32,5 @@ export interface UpdateAssignmentRequest {
     slotId?: string;
     resourceId?: string;
     activityId?: string;
-    weekNum?: number;
+    weekNum?: number | null;
 }

--- a/src/modules/schedule/src/pages/assignments-page/assignments-page.tsx
+++ b/src/modules/schedule/src/pages/assignments-page/assignments-page.tsx
@@ -140,7 +140,7 @@ export function AssignmentsPage() {
 
     const filteredAssignments = useMemo(() => {
         if (filterWeekNum === null) return assignments;
-        return assignments.filter((a) => a.weekNum === filterWeekNum);
+        return assignments.filter((a) => a.weekNum === filterWeekNum || a.weekNum == null);
     }, [assignments, filterWeekNum]);
 
     const fetchAssignments = useCallback(async (

--- a/src/modules/schedule/src/pages/assignments-page/components/add-assignment-modal.tsx
+++ b/src/modules/schedule/src/pages/assignments-page/components/add-assignment-modal.tsx
@@ -101,7 +101,7 @@ export function AddAssignmentModal({
                 setSelectedSlotId(editingAssignment.slotId);
                 setSelectedActivityId(editingAssignment.activityId);
                 setSelectedResourceId(editingAssignment.resourceId);
-                setWeekNum(editingAssignment.weekNum);
+                setWeekNum(editingAssignment.weekNum ?? '');
             } else {
                 setSelectedDay(null);
                 setSelectedSlotId(null);
@@ -124,10 +124,11 @@ export function AddAssignmentModal({
         if (!selectedSlotId) newErrors.slot = "Slot is required";
         if (!selectedActivityId) newErrors.activity = "Activity is required";
         if (!selectedResourceId) newErrors.resource = "Resource is required";
-        if (weekNum === '' || weekNum === null || weekNum === undefined) {
-            newErrors.weekNum = "Week number is required";
-        } else if (Number(weekNum) < 1 || Number(weekNum) > 53) {
-            newErrors.weekNum = resources.weekNumRangeError;
+        if (weekNum !== '' && weekNum !== null && weekNum !== undefined) {
+            const parsedWeekNum = Number(weekNum);
+            if (parsedWeekNum < 1 || parsedWeekNum > 53) {
+                newErrors.weekNum = resources.weekNumRangeError;
+            }
         }
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
@@ -137,6 +138,8 @@ export function AddAssignmentModal({
         e.preventDefault();
         if (!validate()) return;
 
+        const parsedWeekNum = weekNum === '' ? null : Number(weekNum);
+
         setIsSubmitting(true);
         try {
             if (isEditMode && editingAssignment) {
@@ -144,7 +147,7 @@ export function AddAssignmentModal({
                     slotId: selectedSlotId!,
                     resourceId: selectedResourceId!,
                     activityId: selectedActivityId!,
-                    weekNum: weekNum as number,
+                    weekNum: parsedWeekNum,
                 });
                 $app.notifications.showSuccess(
                     notificationResources.successTitle,
@@ -155,7 +158,7 @@ export function AddAssignmentModal({
                     slotId: selectedSlotId!,
                     resourceId: selectedResourceId!,
                     activityId: selectedActivityId!,
-                    weekNum: weekNum as number,
+                    weekNum: parsedWeekNum,
                 });
                 $app.notifications.showSuccess(
                     notificationResources.successTitle,
@@ -236,7 +239,6 @@ export function AddAssignmentModal({
                             });
                         }}
                         error={errors.weekNum}
-                        required
                         min={1}
                         max={53}
                         clampBehavior="none"

--- a/src/modules/schedule/src/pages/assignments-page/components/assignments-data-table.tsx
+++ b/src/modules/schedule/src/pages/assignments-page/components/assignments-data-table.tsx
@@ -24,7 +24,7 @@ interface AssignmentRow {
     userDisplay: string;
     day: string;
     time: string;
-    weekNum: number;
+    weekNum: number | null;
     raw: AssignmentResponse;
 }
 
@@ -121,7 +121,12 @@ export function AssignmentsDataTable({
             }}
         >
             <Column selectionMode="single" headerStyle={{ width: "3rem" }} />
-            <Column field="weekNum" header={resources.weekNumColumn} sortable />
+            <Column
+                field="weekNum"
+                header={resources.weekNumColumn}
+                sortable
+                body={(row: AssignmentRow) => row.weekNum ?? resources.weekNumFilterPlaceholder}
+            />
             <Column field="day" header={resources.dayColumn} sortable />
             <Column field="time" header={resources.timeColumn} sortable />
             <Column field="activityDisplay" header={resources.activityColumn} sortable />

--- a/src/modules/schedule/src/pages/scheduling-periods-page/components/assignment-editor.tsx
+++ b/src/modules/schedule/src/pages/scheduling-periods-page/components/assignment-editor.tsx
@@ -61,7 +61,7 @@ export function AssignmentEditor() {
             if (mode === "edit" && assignment) {
                 setResourceId(assignment.resourceId);
                 setActivityId(assignment.activityId);
-                setWeekNum(assignment.weekNum);
+                setWeekNum(assignment.weekNum ?? '');
             } else {
                 setResourceId(null);
                 setActivityId(null);
@@ -78,10 +78,11 @@ export function AssignmentEditor() {
         if (!activityId) {
             newErrors.activityId = resources.validation.activityRequired;
         }
-        if (weekNum === '' || weekNum === null || weekNum === undefined) {
-            newErrors.weekNum = resources.validation.weekNumRequired;
-        } else if (Number(weekNum) < 1 || Number(weekNum) > 53) {
-            newErrors.weekNum = resources.validation.weekNumRange;
+        if (weekNum !== '' && weekNum !== null && weekNum !== undefined) {
+            const parsedWeekNum = Number(weekNum);
+            if (parsedWeekNum < 1 || parsedWeekNum > 53) {
+                newErrors.weekNum = resources.validation.weekNumRange;
+            }
         }
         setErrors(newErrors);
         return Object.keys(newErrors).length === 0;
@@ -92,6 +93,7 @@ export function AssignmentEditor() {
 
         if (!validate()) return;
 
+        const parsedWeekNum = weekNum === '' ? null : Number(weekNum);
         let success = false;
 
         if (mode === "create" && slotId && resourceId && activityId) {
@@ -99,7 +101,7 @@ export function AssignmentEditor() {
                 slotId,
                 resourceId,
                 activityId,
-                weekNum: weekNum as number,
+                weekNum: parsedWeekNum,
             });
             success = result !== null;
             if (success) {
@@ -118,7 +120,7 @@ export function AssignmentEditor() {
                 slotId: assignment.slotId,
                 resourceId,
                 activityId,
-                weekNum: weekNum as number,
+                weekNum: parsedWeekNum,
             });
             if (success) {
                 $app.notifications.showSuccess(
@@ -218,7 +220,6 @@ export function AssignmentEditor() {
                             });
                         }}
                         error={errors.weekNum}
-                        required
                         min={1}
                         max={53}
                         clampBehavior="none"


### PR DESCRIPTION
## Summary

Make week number optional in the assignment create/edit modals on the manage assignments page (and the scheduling-period assignment editor). Aligns the frontend with backend support for nullable `weekNum` and with existing calendar behavior for all-weeks assignments.

## Changes

- `assignment.types.ts` — `weekNum` is `number | null` on responses; optional/nullable on create/update requests
- `add-assignment-modal.tsx` — remove required validation and UI; send `null` when field is empty; validate range only when a value is entered
- `assignment-editor.tsx` — same optional week number behavior for scheduling-period assignment editor
- `assignments-data-table.tsx` — display “All weeks” when `weekNum` is null
- `assignments-page.tsx` — week filter includes all-weeks assignments when filtering by a specific week

## Why

The calendar already renders assignments without a week number on every relevant week, but the UI forced users to enter a week number and blocked save when the field was empty.

## Test plan

- [ ] Add Assignment — leave week number blank, fill other required fields, save succeeds
- [ ] Edit Assignment — open an all-weeks assignment, field is empty; save without changes succeeds
- [ ] Edit Assignment — clear an existing week number and save; assignment becomes all-weeks
- [ ] Edit Assignment — set a week number (1–53) and save; value persists
- [ ] Enter an out-of-range week number — validation error shown, submit blocked
- [ ] Assignments table shows “All weeks” for null week number
- [ ] Week filter set to a specific week still shows all-weeks assignments
- [ ] Calendar shows blank-week assignments on every matching week in the period

## Related

- Requires: **Chronos.Service** PR above (nullable `WeekNum` on create/update API)
- Deploy backend before or together with this frontend change