### PR TITLE
Fix: Subscribe components to language store to trigger translations re-render

### DIFF
--- a/src/modules/auth/src/pages/profile-settings/profile-settings-page.tsx
+++ b/src/modules/auth/src/pages/profile-settings/profile-settings-page.tsx
@@ -17,7 +17,7 @@ import { translatedResources } from "@/infra/i18n";
 import { useLocaleStore } from "@/infra/theme/state";
 
 export function ProfileSettingsPage() {
-    const language = useLocaleStore(state => state.language);
+    useLocaleStore((state) => state.language);
     const resources = translatedResources("src/modules/auth/src/pages/profile-settings/profile-settings-page.resources.json", resourcesJson);
     const [passwordModalOpen, setPasswordModalOpen] = useState(false);
 

--- a/src/modules/schedule/src/pages/calendar-page/calendar-page.tsx
+++ b/src/modules/schedule/src/pages/calendar-page/calendar-page.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
-import { Box, Flex, Paper, Group, Title, Divider, Text } from "@mantine/core";
+import { Box, Flex, Paper, Title, Divider, Text } from "@mantine/core";
 import { translatedResources } from "@/infra/i18n";
+import { useLocaleStore } from "@/infra/theme/state";
 import notificationResourcesJson from "@/infra/service/notification/notification.resources.json";
 
 const notificationResources = translatedResources(
@@ -29,6 +30,7 @@ interface TimeRangeSelection {
 }
 
 export function CalendarPage() {
+  useLocaleStore((state) => state.language);
   const [selectedPeriodId, setSelectedPeriodId] = useState<string | null>(null);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [timeRangeSelection, setTimeRangeSelection] = useState<TimeRangeSelection | null>(null);

--- a/src/modules/schedule/src/pages/scheduling-periods-page/components/assignment-actions.tsx
+++ b/src/modules/schedule/src/pages/scheduling-periods-page/components/assignment-actions.tsx
@@ -21,7 +21,7 @@ export function AssignmentActions({
     onEditClick,
     onDeleteClick,
 }: AssignmentActionsProps) {
-    const language = useLocaleStore((state) => state.language);
+    useLocaleStore((state) => state.language);
     const resources = translatedResources(
         "src/modules/schedule/src/pages/assignments-page/assignments-page.resources.json",
         resourcesJson


### PR DESCRIPTION
Added useLocaleStore to components that had it removed to prevent the unused variable typescript error. This ensures components automatically re-render when the user switches languages.